### PR TITLE
feat: create shares

### DIFF
--- a/snowbird/models.py
+++ b/snowbird/models.py
@@ -106,6 +106,16 @@ class SnowbirdUsers(Users):
     root: Dict[str, SnowbirdUser]
 
 
+class SnowbirdShare(BaseModel):
+    owner: str = None
+    consumers: List[str] = None
+    privileges: Privileges = None
+
+
+class SnowbirdShares(DictModel):
+    root: Dict[str, SnowbirdShare]
+
+
 class PermifrostModel(BaseModel):
     databases: Optional[List[Databases]] = None
     warehouses: Optional[List[Warehouses]] = None
@@ -118,3 +128,4 @@ class SnowbirdModel(PermifrostModel):
     warehouses: Optional[List[SnowbirdWarehouses]] = None
     roles: Optional[List[SnowbirdRoles]] = None
     users: Optional[List[SnowbirdUsers]] = None
+    shares: Optional[List[SnowbirdShares]] = None

--- a/tests/infrastructure/snowflake.yml
+++ b/tests/infrastructure/snowflake.yml
@@ -2,111 +2,121 @@ version: "1.0"
 
 # Databases
 databases:
-    - vdl_ssb:
-        shared: no
-        schemas:
-            - raw
-            - stage
-            - reporting
-            - open
+  - vdl_ssb:
+      shared: no
+      schemas:
+        - raw
+        - stage
+        - reporting
+        - open
 
 # Roles
 roles:
-    ## System Roles
-    - vdl_ssb_loader:
-        member_of:
-            - sysadmin
-        warehouses:
-            - vdl_ssb_loading
-        privileges:
-            databases:
-                read:
-                    - vdl_ssb
-                write:
-                    - vdl_ssb
-            schemas:
-                read:
-                    - vdl_ssb.raw
-                write:
-                    - vdl_ssb.raw
-            tables:
-                read:
-                    - vdl_ssb.raw.*
-                write:
-                    - vdl_ssb.raw.*
-   
-   
-    - vdl_ssb_transformer:
-        member_of:
-            - sysadmin
-        warehouses:
-            - vdl_ssb_transforming
-        privileges:
-            databases:
-                read:
-                    - vdl_ssb
-                write:
-                    - vdl_ssb
-            schemas:
-                read:
-                    - vdl_ssb.*
-                write:
-                    - vdl_ssb.transformed
-                    - vdl_ssb.reporting
-                    - vdl_ssb.internal
-            tables:
-                read:
-                    - vdl_ssb.raw.*
-                write:
-                    - vdl_ssb.transformed.*
-                    - vdl_ssb.reporting.*
-                    - vdl_ssb.internal.*
-                    
-                    
-    - vdl_ssb_reporter:
-        member_of:
-            - public
-        warehouses:
-            - vdl_ssb_reporting
-        privileges:
-            databases:
-                read:
-                    - vdl_ssb
-                write:
-                    - vdl_ssb
-            schemas:
-                read:
-                    - vdl_ssb.reporting
-                write:
-                     - vdl_ssb.public
-            tables:
-                read:
-                    - vdl_ssb.reporting.*
-                    - vdl_ssb.internal.*
-                write:
-                     - vdl_ssb.public.*
+  ## System Roles
+  - vdl_ssb_loader:
+      member_of:
+        - sysadmin
+      warehouses:
+        - vdl_ssb_loading
+      privileges:
+        databases:
+          read:
+            - vdl_ssb
+          write:
+            - vdl_ssb
+        schemas:
+          read:
+            - vdl_ssb.raw
+          write:
+            - vdl_ssb.raw
+        tables:
+          read:
+            - vdl_ssb.raw.*
+          write:
+            - vdl_ssb.raw.*
 
+  - vdl_ssb_transformer:
+      member_of:
+        - sysadmin
+      warehouses:
+        - vdl_ssb_transforming
+      privileges:
+        databases:
+          read:
+            - vdl_ssb
+          write:
+            - vdl_ssb
+        schemas:
+          read:
+            - vdl_ssb.*
+          write:
+            - vdl_ssb.transformed
+            - vdl_ssb.reporting
+            - vdl_ssb.internal
+        tables:
+          read:
+            - vdl_ssb.raw.*
+          write:
+            - vdl_ssb.transformed.*
+            - vdl_ssb.reporting.*
+            - vdl_ssb.internal.*
+
+  - vdl_ssb_reporter:
+      member_of:
+        - public
+      warehouses:
+        - vdl_ssb_reporting
+      privileges:
+        databases:
+          read:
+            - vdl_ssb
+          write:
+            - vdl_ssb
+        schemas:
+          read:
+            - vdl_ssb.reporting
+          write:
+            - vdl_ssb.public
+        tables:
+          read:
+            - vdl_ssb.reporting.*
+            - vdl_ssb.internal.*
+          write:
+            - vdl_ssb.public.*
 
 # Users
 users:
-    - vdl_ssb_loader:
-        can_login: yes
-        member_of:
-            - vdl_ssb_loader
+  - vdl_ssb_loader:
+      can_login: yes
+      member_of:
+        - vdl_ssb_loader
 
-    - vdl_ssb_transformer:
-        can_login: yes
-        member_of:
-            - vdl_ssb_transformer
-
+  - vdl_ssb_transformer:
+      can_login: yes
+      member_of:
+        - vdl_ssb_transformer
 
 # Warehouses
 warehouses:
-    - vdl_ssb_loading:
-        size: x-small
+  - vdl_ssb_loading:
+      size: x-small
 
-    - vdl_ssb_reporting:
-        size: x-small
+  - vdl_ssb_reporting:
+      size: x-small
 
-    - vdl_ssb_transforming:
-        size: x-small
+  - vdl_ssb_transforming:
+      size: x-small
+
+# Shares
+shares:
+  - vdl_ssb_share:
+      owner: vdl_ssb_transformer
+      consumers:
+        - foo.bar
+      privileges:
+        databases:
+          read:
+            - vdl_ssb
+        schemas:
+          read:
+            - vdl_ssb.reporting


### PR DESCRIPTION
This feature will create shares with defined owner, consumers and
grant read (usage) privileges on databases and schemas.

Defining which tables and views the should be shared is not implemented
and is for now considered the role of dbt.

Changing the owner of an already existing share is not implemented
because this requires comparing the state of the share in snowflake.
This adds complexity and should only be implemented if it becomes a
recurring problem.

Jira: https://jira.adeo.no/browse/VDL-195