### PR TITLE
feat(grants)!: stateful grant and revoke diffing

### DIFF
--- a/.agents/skills/caveman-commit/SKILL.md
+++ b/.agents/skills/caveman-commit/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: caveman-commit
+description: >
+  Ultra-compressed commit message generator. Cuts noise from commit messages while preserving
+  intent and reasoning. Conventional Commits format. Subject ≤50 chars, body only when "why"
+  isn't obvious. Use when user says "write a commit", "commit message", "generate commit",
+  "/commit", or invokes /caveman-commit. Auto-triggers when staging changes.
+---
+
+Write commit messages terse and exact. Conventional Commits format. No fluff. Why over what.
+
+## Rules
+
+**Subject line:**
+- `<type>(<scope>): <imperative summary>` — `<scope>` optional
+- Types: `feat`, `fix`, `refactor`, `perf`, `docs`, `test`, `chore`, `build`, `ci`, `style`, `revert`
+- Imperative mood: "add", "fix", "remove" — not "added", "adds", "adding"
+- ≤50 chars when possible, hard cap 72
+- No trailing period
+- Match project convention for capitalization after the colon
+
+**Body (only if needed):**
+- Skip entirely when subject is self-explanatory
+- Add body only for: non-obvious *why*, breaking changes, migration notes, linked issues
+- Wrap at 72 chars
+- Bullets `-` not `*`
+- Reference issues/PRs at end: `Closes #42`, `Refs #17`
+
+**What NEVER goes in:**
+- "This commit does X", "I", "we", "now", "currently" — the diff says what
+- "As requested by..." — use Co-authored-by trailer
+- "Generated with Claude Code" or any AI attribution
+- Emoji (unless project convention requires)
+- Restating the file name when scope already says it
+
+## Examples
+
+Diff: new endpoint for user profile with body explaining the why
+- ❌ "feat: add a new endpoint to get user profile information from the database"
+- ✅
+  ```
+  feat(api): add GET /users/:id/profile
+
+  Mobile client needs profile data without the full user payload
+  to reduce LTE bandwidth on cold-launch screens.
+
+  Closes #128
+  ```
+
+Diff: breaking API change
+- ✅
+  ```
+  feat(api)!: rename /v1/orders to /v1/checkout
+
+  BREAKING CHANGE: clients on /v1/orders must migrate to /v1/checkout
+  before 2026-06-01. Old route returns 410 after that date.
+  ```
+
+## Auto-Clarity
+
+Always include body for: breaking changes, security fixes, data migrations, anything reverting a prior commit. Never compress these into subject-only — future debuggers need the context.
+
+## Boundaries
+
+Only generates the commit message. Does not run `git commit`, does not stage files, does not amend. Output the message as a code block ready to paste. "stop caveman-commit" or "normal mode": revert to verbose commit style.

--- a/.agents/skills/caveman-compress/README.md
+++ b/.agents/skills/caveman-compress/README.md
@@ -1,0 +1,163 @@
+<p align="center">
+  <img src="https://em-content.zobj.net/source/apple/391/rock_1faa8.png" width="80" />
+</p>
+
+<h1 align="center">caveman-compress</h1>
+
+<p align="center">
+  <strong>shrink memory file. save token every session.</strong>
+</p>
+
+---
+
+A Claude Code skill that compresses your project memory files (`CLAUDE.md`, todos, preferences) into caveman format — so every session loads fewer tokens automatically.
+
+Claude read `CLAUDE.md` on every session start. If file big, cost big. Caveman make file small. Cost go down forever.
+
+## What It Do
+
+```
+/caveman:compress CLAUDE.md
+```
+
+```
+CLAUDE.md          ← compressed (Claude reads this — fewer tokens every session)
+CLAUDE.original.md ← human-readable backup (you edit this)
+```
+
+Original never lost. You can read and edit `.original.md`. Run skill again to re-compress after edits.
+
+## Benchmarks
+
+Real results on real project files:
+
+| File | Original | Compressed | Saved |
+|------|----------:|----------:|------:|
+| `claude-md-preferences.md` | 706 | 285 | **59.6%** |
+| `project-notes.md` | 1145 | 535 | **53.3%** |
+| `claude-md-project.md` | 1122 | 636 | **43.3%** |
+| `todo-list.md` | 627 | 388 | **38.1%** |
+| `mixed-with-code.md` | 888 | 560 | **36.9%** |
+| **Average** | **898** | **481** | **46%** |
+
+All validations passed ✅ — headings, code blocks, URLs, file paths preserved exactly.
+
+## Before / After
+
+<table>
+<tr>
+<td width="50%">
+
+### 📄 Original (706 tokens)
+
+> "I strongly prefer TypeScript with strict mode enabled for all new code. Please don't use `any` type unless there's genuinely no way around it, and if you do, leave a comment explaining the reasoning. I find that taking the time to properly type things catches a lot of bugs before they ever make it to runtime."
+
+</td>
+<td width="50%">
+
+### 🪨 Caveman (285 tokens)
+
+> "Prefer TypeScript strict mode always. No `any` unless unavoidable — comment why if used. Proper types catch bugs early."
+
+</td>
+</tr>
+</table>
+
+**Same instructions. 60% fewer tokens. Every. Single. Session.**
+
+## Security
+
+`caveman-compress` is flagged as Snyk High Risk due to subprocess and file I/O patterns detected by static analysis. This is a false positive — see [SECURITY.md](./SECURITY.md) for a full explanation of what the skill does and does not do.
+
+## Install
+
+Compress is built in with the `caveman` plugin. Install `caveman` once, then use `/caveman:compress`.
+
+If you need local files, the compress skill lives at:
+
+```bash
+caveman-compress/
+```
+
+**Requires:** Python 3.10+
+
+## Usage
+
+```
+/caveman:compress <filepath>
+```
+
+Examples:
+```
+/caveman:compress CLAUDE.md
+/caveman:compress docs/preferences.md
+/caveman:compress todos.md
+```
+
+### What files work
+
+| Type | Compress? |
+|------|-----------|
+| `.md`, `.txt`, `.rst` | ✅ Yes |
+| Extensionless natural language | ✅ Yes |
+| `.py`, `.js`, `.ts`, `.json`, `.yaml` | ❌ Skip (code/config) |
+| `*.original.md` | ❌ Skip (backup files) |
+
+## How It Work
+
+```
+/caveman:compress CLAUDE.md
+        ↓
+detect file type        (no tokens)
+        ↓
+Claude compresses       (tokens — one call)
+        ↓
+validate output         (no tokens)
+  checks: headings, code blocks, URLs, file paths, bullets
+        ↓
+if errors: Claude fixes cherry-picked issues only   (tokens — targeted fix)
+  does NOT recompress — only patches broken parts
+        ↓
+retry up to 2 times
+        ↓
+write compressed → CLAUDE.md
+write original   → CLAUDE.original.md
+```
+
+Only two things use tokens: initial compression + targeted fix if validation fails. Everything else is local Python.
+
+## What Is Preserved
+
+Caveman compress natural language. It never touch:
+
+- Code blocks (` ``` ` fenced or indented)
+- Inline code (`` `backtick content` ``)
+- URLs and links
+- File paths (`/src/components/...`)
+- Commands (`npm install`, `git commit`)
+- Technical terms, library names, API names
+- Headings (exact text preserved)
+- Tables (structure preserved, cell text compressed)
+- Dates, version numbers, numeric values
+
+## Why This Matter
+
+`CLAUDE.md` loads on **every session start**. A 1000-token project memory file costs tokens every single time you open a project. Over 100 sessions that's 100,000 tokens of overhead — just for context you already wrote.
+
+Caveman cut that by ~46% on average. Same instructions. Same accuracy. Less waste.
+
+```
+┌────────────────────────────────────────────┐
+│  TOKEN SAVINGS PER FILE    █████       46% │
+│  SESSIONS THAT BENEFIT     ██████████ 100% │
+│  INFORMATION PRESERVED     ██████████ 100% │
+│  SETUP TIME                █            1x │
+└────────────────────────────────────────────┘
+```
+
+## Part of Caveman
+
+This skill is part of the [caveman](https://github.com/JuliusBrussee/caveman) toolkit — making Claude use fewer tokens without losing accuracy.
+
+- **caveman** — make Claude *speak* like caveman (cuts response tokens ~65%)
+- **caveman-compress** — make Claude *read* less (cuts context tokens ~46%)

--- a/.agents/skills/caveman-compress/SECURITY.md
+++ b/.agents/skills/caveman-compress/SECURITY.md
@@ -1,0 +1,31 @@
+# Security
+
+## Snyk High Risk Rating
+
+`caveman-compress` receives a Snyk High Risk rating due to static analysis heuristics. This document explains what the skill does and does not do.
+
+### What triggers the rating
+
+1. **subprocess usage**: The skill calls the `claude` CLI via `subprocess.run()` as a fallback when `ANTHROPIC_API_KEY` is not set. The subprocess call uses a fixed argument list — no shell interpolation occurs. User file content is passed via stdin, not as a shell argument.
+
+2. **File read/write**: The skill reads the file the user explicitly points it at, compresses it, and writes the result back to the same path. A `.original.md` backup is saved alongside it. No files outside the user-specified path are read or written.
+
+### What the skill does NOT do
+
+- Does not execute user file content as code
+- Does not make network requests except to Anthropic's API (via SDK or CLI)
+- Does not access files outside the path the user provides
+- Does not use shell=True or string interpolation in subprocess calls
+- Does not collect or transmit any data beyond the file being compressed
+
+### Auth behavior
+
+If `ANTHROPIC_API_KEY` is set, the skill uses the Anthropic Python SDK directly (no subprocess). If not set, it falls back to the `claude` CLI, which uses the user's existing Claude desktop authentication.
+
+### File size limit
+
+Files larger than 500KB are rejected before any API call is made.
+
+### Reporting a vulnerability
+
+If you believe you've found a genuine security issue, please open a GitHub issue with the label `security`.

--- a/.agents/skills/caveman-compress/SKILL.md
+++ b/.agents/skills/caveman-compress/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: caveman-compress
+description: >
+  Compress natural language memory files (CLAUDE.md, todos, preferences) into caveman format
+  to save input tokens. Preserves all technical substance, code, URLs, and structure.
+  Compressed version overwrites the original file. Human-readable backup saved as FILE.original.md.
+  Trigger: /caveman:compress <filepath> or "compress memory file"
+---
+
+# Caveman Compress
+
+## Purpose
+
+Compress natural language files (CLAUDE.md, todos, preferences) into caveman-speak to reduce input tokens. Compressed version overwrites original. Human-readable backup saved as `<filename>.original.md`.
+
+## Trigger
+
+`/caveman:compress <filepath>` or when user asks to compress a memory file.
+
+## Process
+
+1. The compression scripts live in `caveman-compress/scripts/` (adjacent to this SKILL.md). If the path is not immediately available, search for `caveman-compress/scripts/__main__.py`.
+
+2. Run:
+
+cd caveman-compress && python3 -m scripts <absolute_filepath>
+
+3. The CLI will:
+- detect file type (no tokens)
+- call Claude to compress
+- validate output (no tokens)
+- if errors: cherry-pick fix with Claude (targeted fixes only, no recompression)
+- retry up to 2 times
+- if still failing after 2 retries: report error to user, leave original file untouched
+
+4. Return result to user
+
+## Compression Rules
+
+### Remove
+- Articles: a, an, the
+- Filler: just, really, basically, actually, simply, essentially, generally
+- Pleasantries: "sure", "certainly", "of course", "happy to", "I'd recommend"
+- Hedging: "it might be worth", "you could consider", "it would be good to"
+- Redundant phrasing: "in order to" → "to", "make sure to" → "ensure", "the reason is because" → "because"
+- Connective fluff: "however", "furthermore", "additionally", "in addition"
+
+### Preserve EXACTLY (never modify)
+- Code blocks (fenced ``` and indented)
+- Inline code (`backtick content`)
+- URLs and links (full URLs, markdown links)
+- File paths (`/src/components/...`, `./config.yaml`)
+- Commands (`npm install`, `git commit`, `docker build`)
+- Technical terms (library names, API names, protocols, algorithms)
+- Proper nouns (project names, people, companies)
+- Dates, version numbers, numeric values
+- Environment variables (`$HOME`, `NODE_ENV`)
+
+### Preserve Structure
+- All markdown headings (keep exact heading text, compress body below)
+- Bullet point hierarchy (keep nesting level)
+- Numbered lists (keep numbering)
+- Tables (compress cell text, keep structure)
+- Frontmatter/YAML headers in markdown files
+
+### Compress
+- Use short synonyms: "big" not "extensive", "fix" not "implement a solution for", "use" not "utilize"
+- Fragments OK: "Run tests before commit" not "You should always run tests before committing"
+- Drop "you should", "make sure to", "remember to" — just state the action
+- Merge redundant bullets that say the same thing differently
+- Keep one example where multiple examples show the same pattern
+
+CRITICAL RULE:
+Anything inside ``` ... ``` must be copied EXACTLY.
+Do not:
+- remove comments
+- remove spacing
+- reorder lines
+- shorten commands
+- simplify anything
+
+Inline code (`...`) must be preserved EXACTLY.
+Do not modify anything inside backticks.
+
+If file contains code blocks:
+- Treat code blocks as read-only regions
+- Only compress text outside them
+- Do not merge sections around code
+
+## Pattern
+
+Original:
+> You should always make sure to run the test suite before pushing any changes to the main branch. This is important because it helps catch bugs early and prevents broken builds from being deployed to production.
+
+Compressed:
+> Run tests before push to main. Catch bugs early, prevent broken prod deploys.
+
+Original:
+> The application uses a microservices architecture with the following components. The API gateway handles all incoming requests and routes them to the appropriate service. The authentication service is responsible for managing user sessions and JWT tokens.
+
+Compressed:
+> Microservices architecture. API gateway route all requests to services. Auth service manage user sessions + JWT tokens.
+
+## Boundaries
+
+- ONLY compress natural language files (.md, .txt, extensionless)
+- NEVER modify: .py, .js, .ts, .json, .yaml, .yml, .toml, .env, .lock, .css, .html, .xml, .sql, .sh
+- If file has mixed content (prose + code), compress ONLY the prose sections
+- If unsure whether something is code or prose, leave it unchanged
+- Original file is backed up as FILE.original.md before overwriting
+- Never compress FILE.original.md (skip it)

--- a/.agents/skills/caveman-compress/scripts/__init__.py
+++ b/.agents/skills/caveman-compress/scripts/__init__.py
@@ -1,0 +1,9 @@
+"""Caveman compress scripts.
+
+This package provides tools to compress natural language markdown files
+into caveman format to save input tokens.
+"""
+
+__all__ = ["cli", "compress", "detect", "validate"]
+
+__version__ = "1.0.0"

--- a/.agents/skills/caveman-compress/scripts/__main__.py
+++ b/.agents/skills/caveman-compress/scripts/__main__.py
@@ -1,0 +1,3 @@
+from .cli import main
+
+main()

--- a/.agents/skills/caveman-compress/scripts/benchmark.py
+++ b/.agents/skills/caveman-compress/scripts/benchmark.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import sys
+
+# Support both direct execution and module import
+try:
+    from .validate import validate
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).parent))
+    from validate import validate
+
+try:
+    import tiktoken
+    _enc = tiktoken.get_encoding("o200k_base")
+except ImportError:
+    _enc = None
+
+
+def count_tokens(text):
+    if _enc is None:
+        return len(text.split())  # fallback: word count
+    return len(_enc.encode(text))
+
+
+def benchmark_pair(orig_path: Path, comp_path: Path):
+    orig_text = orig_path.read_text()
+    comp_text = comp_path.read_text()
+
+    orig_tokens = count_tokens(orig_text)
+    comp_tokens = count_tokens(comp_text)
+    saved = 100 * (orig_tokens - comp_tokens) / orig_tokens if orig_tokens > 0 else 0.0
+    result = validate(orig_path, comp_path)
+
+    return (comp_path.name, orig_tokens, comp_tokens, saved, result.is_valid)
+
+
+def print_table(rows):
+    print("\n| File | Original | Compressed | Saved % | Valid |")
+    print("|------|----------|------------|---------|-------|")
+    for r in rows:
+        print(f"| {r[0]} | {r[1]} | {r[2]} | {r[3]:.1f}% | {'✅' if r[4] else '❌'} |")
+
+
+def main():
+    # Direct file pair: python3 benchmark.py original.md compressed.md
+    if len(sys.argv) == 3:
+        orig = Path(sys.argv[1]).resolve()
+        comp = Path(sys.argv[2]).resolve()
+        if not orig.exists():
+            print(f"❌ Not found: {orig}")
+            sys.exit(1)
+        if not comp.exists():
+            print(f"❌ Not found: {comp}")
+            sys.exit(1)
+        print_table([benchmark_pair(orig, comp)])
+        return
+
+    # Glob mode: repo_root/tests/caveman-compress/
+    tests_dir = Path(__file__).parent.parent.parent / "tests" / "caveman-compress"
+    if not tests_dir.exists():
+        print(f"❌ Tests dir not found: {tests_dir}")
+        sys.exit(1)
+
+    rows = []
+    for orig in sorted(tests_dir.glob("*.original.md")):
+        comp = orig.with_name(orig.stem.removesuffix(".original") + ".md")
+        if comp.exists():
+            rows.append(benchmark_pair(orig, comp))
+
+    if not rows:
+        print("No compressed file pairs found.")
+        return
+
+    print_table(rows)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/caveman-compress/scripts/cli.py
+++ b/.agents/skills/caveman-compress/scripts/cli.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""
+Caveman Compress CLI
+
+Usage:
+    caveman <filepath>
+"""
+
+import sys
+from pathlib import Path
+
+from .compress import compress_file
+from .detect import detect_file_type, should_compress
+
+
+def print_usage():
+    print("Usage: caveman <filepath>")
+
+
+def main():
+    if len(sys.argv) != 2:
+        print_usage()
+        sys.exit(1)
+
+    filepath = Path(sys.argv[1])
+
+    # Check file exists
+    if not filepath.exists():
+        print(f"❌ File not found: {filepath}")
+        sys.exit(1)
+
+    if not filepath.is_file():
+        print(f"❌ Not a file: {filepath}")
+        sys.exit(1)
+
+    filepath = filepath.resolve()
+
+    # Detect file type
+    file_type = detect_file_type(filepath)
+
+    print(f"Detected: {file_type}")
+
+    # Check if compressible
+    if not should_compress(filepath):
+        print("Skipping: file is not natural language (code/config)")
+        sys.exit(0)
+
+    print("Starting caveman compression...\n")
+
+    try:
+        success = compress_file(filepath)
+
+        if success:
+            print("\nCompression completed successfully")
+            backup_path = filepath.with_name(filepath.stem + ".original.md")
+            print(f"Compressed: {filepath}")
+            print(f"Original:   {backup_path}")
+            sys.exit(0)
+        else:
+            print("\n❌ Compression failed after retries")
+            sys.exit(2)
+
+    except KeyboardInterrupt:
+        print("\nInterrupted by user")
+        sys.exit(130)
+
+    except Exception as e:
+        print(f"\n❌ Error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/caveman-compress/scripts/compress.py
+++ b/.agents/skills/caveman-compress/scripts/compress.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""
+Caveman Memory Compression Orchestrator
+
+Usage:
+    python scripts/compress.py <filepath>
+"""
+
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import List
+
+OUTER_FENCE_REGEX = re.compile(
+    r"\A\s*(`{3,}|~{3,})[^\n]*\n(.*)\n\1\s*\Z", re.DOTALL
+)
+
+# Filenames and paths that almost certainly hold secrets or PII. Compressing
+# them ships raw bytes to the Anthropic API — a third-party data boundary that
+# developers on sensitive codebases cannot cross. detect.py already skips .env
+# by extension, but credentials.md / secrets.txt / ~/.aws/credentials would
+# slip through the natural-language filter. This is a hard refuse before read.
+SENSITIVE_BASENAME_REGEX = re.compile(
+    r"(?ix)^("
+    r"\.env(\..+)?"
+    r"|\.netrc"
+    r"|credentials(\..+)?"
+    r"|secrets?(\..+)?"
+    r"|passwords?(\..+)?"
+    r"|id_(rsa|dsa|ecdsa|ed25519)(\.pub)?"
+    r"|authorized_keys"
+    r"|known_hosts"
+    r"|.*\.(pem|key|p12|pfx|crt|cer|jks|keystore|asc|gpg)"
+    r")$"
+)
+
+SENSITIVE_PATH_COMPONENTS = frozenset({".ssh", ".aws", ".gnupg", ".kube", ".docker"})
+
+SENSITIVE_NAME_TOKENS = (
+    "secret", "credential", "password", "passwd",
+    "apikey", "accesskey", "token", "privatekey",
+)
+
+
+def is_sensitive_path(filepath: Path) -> bool:
+    """Heuristic denylist for files that must never be shipped to a third-party API."""
+    name = filepath.name
+    if SENSITIVE_BASENAME_REGEX.match(name):
+        return True
+    lowered_parts = {p.lower() for p in filepath.parts}
+    if lowered_parts & SENSITIVE_PATH_COMPONENTS:
+        return True
+    # Normalize separators so "api-key" and "api_key" both match "apikey".
+    lower = re.sub(r"[_\-\s.]", "", name.lower())
+    return any(tok in lower for tok in SENSITIVE_NAME_TOKENS)
+
+
+def strip_llm_wrapper(text: str) -> str:
+    """Strip outer ```markdown ... ``` fence when it wraps the entire output."""
+    m = OUTER_FENCE_REGEX.match(text)
+    if m:
+        return m.group(2)
+    return text
+
+from .detect import should_compress
+from .validate import validate
+
+MAX_RETRIES = 2
+
+
+# ---------- Claude Calls ----------
+
+
+def call_claude(prompt: str) -> str:
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if api_key:
+        try:
+            import anthropic
+
+            client = anthropic.Anthropic(api_key=api_key)
+            msg = client.messages.create(
+                model=os.environ.get("CAVEMAN_MODEL", "claude-sonnet-4-5"),
+                max_tokens=8192,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            return strip_llm_wrapper(msg.content[0].text.strip())
+        except ImportError:
+            pass  # anthropic not installed, fall back to CLI
+    # Fallback: use claude CLI (handles desktop auth)
+    try:
+        result = subprocess.run(
+            ["claude", "--print"],
+            input=prompt,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        return strip_llm_wrapper(result.stdout.strip())
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"Claude call failed:\n{e.stderr}")
+
+
+def build_compress_prompt(original: str) -> str:
+    return f"""
+Compress this markdown into caveman format.
+
+STRICT RULES:
+- Do NOT modify anything inside ``` code blocks
+- Do NOT modify anything inside inline backticks
+- Preserve ALL URLs exactly
+- Preserve ALL headings exactly
+- Preserve file paths and commands
+- Return ONLY the compressed markdown body — do NOT wrap the entire output in a ```markdown fence or any other fence. Inner code blocks from the original stay as-is; do not add a new outer fence around the whole file.
+
+Only compress natural language.
+
+TEXT:
+{original}
+"""
+
+
+def build_fix_prompt(original: str, compressed: str, errors: List[str]) -> str:
+    errors_str = "\n".join(f"- {e}" for e in errors)
+    return f"""You are fixing a caveman-compressed markdown file. Specific validation errors were found.
+
+CRITICAL RULES:
+- DO NOT recompress or rephrase the file
+- ONLY fix the listed errors — leave everything else exactly as-is
+- The ORIGINAL is provided as reference only (to restore missing content)
+- Preserve caveman style in all untouched sections
+
+ERRORS TO FIX:
+{errors_str}
+
+HOW TO FIX:
+- Missing URL: find it in ORIGINAL, restore it exactly where it belongs in COMPRESSED
+- Code block mismatch: find the exact code block in ORIGINAL, restore it in COMPRESSED
+- Heading mismatch: restore the exact heading text from ORIGINAL into COMPRESSED
+- Do not touch any section not mentioned in the errors
+
+ORIGINAL (reference only):
+{original}
+
+COMPRESSED (fix this):
+{compressed}
+
+Return ONLY the fixed compressed file. No explanation.
+"""
+
+
+# ---------- Core Logic ----------
+
+
+def compress_file(filepath: Path) -> bool:
+    # Resolve and validate path
+    filepath = filepath.resolve()
+    MAX_FILE_SIZE = 500_000  # 500KB
+    if not filepath.exists():
+        raise FileNotFoundError(f"File not found: {filepath}")
+    if filepath.stat().st_size > MAX_FILE_SIZE:
+        raise ValueError(f"File too large to compress safely (max 500KB): {filepath}")
+
+    # Refuse files that look like they contain secrets or PII. Compressing ships
+    # the raw bytes to the Anthropic API — a third-party boundary — so we fail
+    # loudly rather than silently exfiltrate credentials or keys. Override is
+    # intentional: the user must rename the file if the heuristic is wrong.
+    if is_sensitive_path(filepath):
+        raise ValueError(
+            f"Refusing to compress {filepath}: filename looks sensitive "
+            "(credentials, keys, secrets, or known private paths). "
+            "Compression sends file contents to the Anthropic API. "
+            "Rename the file if this is a false positive."
+        )
+
+    print(f"Processing: {filepath}")
+
+    if not should_compress(filepath):
+        print("Skipping (not natural language)")
+        return False
+
+    original_text = filepath.read_text(errors="ignore")
+    backup_path = filepath.with_name(filepath.stem + ".original.md")
+
+    # Check if backup already exists to prevent accidental overwriting
+    if backup_path.exists():
+        print(f"⚠️ Backup file already exists: {backup_path}")
+        print("The original backup may contain important content.")
+        print("Aborting to prevent data loss. Please remove or rename the backup file if you want to proceed.")
+        return False
+
+    # Step 1: Compress
+    print("Compressing with Claude...")
+    compressed = call_claude(build_compress_prompt(original_text))
+
+    # Save original as backup, write compressed to original path
+    backup_path.write_text(original_text)
+    filepath.write_text(compressed)
+
+    # Step 2: Validate + Retry
+    for attempt in range(MAX_RETRIES):
+        print(f"\nValidation attempt {attempt + 1}")
+
+        result = validate(backup_path, filepath)
+
+        if result.is_valid:
+            print("Validation passed")
+            break
+
+        print("❌ Validation failed:")
+        for err in result.errors:
+            print(f"   - {err}")
+
+        if attempt == MAX_RETRIES - 1:
+            # Restore original on failure
+            filepath.write_text(original_text)
+            backup_path.unlink(missing_ok=True)
+            print("❌ Failed after retries — original restored")
+            return False
+
+        print("Fixing with Claude...")
+        compressed = call_claude(
+            build_fix_prompt(original_text, compressed, result.errors)
+        )
+        filepath.write_text(compressed)
+
+    return True

--- a/.agents/skills/caveman-compress/scripts/detect.py
+++ b/.agents/skills/caveman-compress/scripts/detect.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Detect whether a file is natural language (compressible) or code/config (skip)."""
+
+import json
+import re
+from pathlib import Path
+
+# Extensions that are natural language and compressible
+COMPRESSIBLE_EXTENSIONS = {".md", ".txt", ".markdown", ".rst"}
+
+# Extensions that are code/config and should be skipped
+SKIP_EXTENSIONS = {
+    ".py", ".js", ".ts", ".tsx", ".jsx", ".json", ".yaml", ".yml",
+    ".toml", ".env", ".lock", ".css", ".scss", ".html", ".xml",
+    ".sql", ".sh", ".bash", ".zsh", ".go", ".rs", ".java", ".c",
+    ".cpp", ".h", ".hpp", ".rb", ".php", ".swift", ".kt", ".lua",
+    ".dockerfile", ".makefile", ".csv", ".ini", ".cfg",
+}
+
+# Patterns that indicate a line is code
+CODE_PATTERNS = [
+    re.compile(r"^\s*(import |from .+ import |require\(|const |let |var )"),
+    re.compile(r"^\s*(def |class |function |async function |export )"),
+    re.compile(r"^\s*(if\s*\(|for\s*\(|while\s*\(|switch\s*\(|try\s*\{)"),
+    re.compile(r"^\s*[\}\]\);]+\s*$"),  # closing braces/brackets
+    re.compile(r"^\s*@\w+"),  # decorators/annotations
+    re.compile(r'^\s*"[^"]+"\s*:\s*'),  # JSON-like key-value
+    re.compile(r"^\s*\w+\s*=\s*[{\[\(\"']"),  # assignment with literal
+]
+
+
+def _is_code_line(line: str) -> bool:
+    """Check if a line looks like code."""
+    return any(p.match(line) for p in CODE_PATTERNS)
+
+
+def _is_json_content(text: str) -> bool:
+    """Check if content is valid JSON."""
+    try:
+        json.loads(text)
+        return True
+    except (json.JSONDecodeError, ValueError):
+        return False
+
+
+def _is_yaml_content(lines: list[str]) -> bool:
+    """Heuristic: check if content looks like YAML."""
+    yaml_indicators = 0
+    for line in lines[:30]:
+        stripped = line.strip()
+        if stripped.startswith("---"):
+            yaml_indicators += 1
+        elif re.match(r"^\w[\w\s]*:\s", stripped):
+            yaml_indicators += 1
+        elif stripped.startswith("- ") and ":" in stripped:
+            yaml_indicators += 1
+    # If most non-empty lines look like YAML
+    non_empty = sum(1 for l in lines[:30] if l.strip())
+    return non_empty > 0 and yaml_indicators / non_empty > 0.6
+
+
+def detect_file_type(filepath: Path) -> str:
+    """Classify a file as 'natural_language', 'code', 'config', or 'unknown'.
+
+    Returns:
+        One of: 'natural_language', 'code', 'config', 'unknown'
+    """
+    ext = filepath.suffix.lower()
+
+    # Extension-based classification
+    if ext in COMPRESSIBLE_EXTENSIONS:
+        return "natural_language"
+    if ext in SKIP_EXTENSIONS:
+        return "code" if ext not in {".json", ".yaml", ".yml", ".toml", ".ini", ".cfg", ".env"} else "config"
+
+    # Extensionless files (like CLAUDE.md, TODO) — check content
+    if not ext:
+        try:
+            text = filepath.read_text(errors="ignore")
+        except (OSError, PermissionError):
+            return "unknown"
+
+        lines = text.splitlines()[:50]
+
+        if _is_json_content(text[:10000]):
+            return "config"
+        if _is_yaml_content(lines):
+            return "config"
+
+        code_lines = sum(1 for l in lines if l.strip() and _is_code_line(l))
+        non_empty = sum(1 for l in lines if l.strip())
+        if non_empty > 0 and code_lines / non_empty > 0.4:
+            return "code"
+
+        return "natural_language"
+
+    return "unknown"
+
+
+def should_compress(filepath: Path) -> bool:
+    """Return True if the file is natural language and should be compressed."""
+    if not filepath.is_file():
+        return False
+    # Skip backup files
+    if filepath.name.endswith(".original.md"):
+        return False
+    return detect_file_type(filepath) == "natural_language"
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) < 2:
+        print("Usage: python detect.py <file1> [file2] ...")
+        sys.exit(1)
+
+    for path_str in sys.argv[1:]:
+        p = Path(path_str).resolve()
+        file_type = detect_file_type(p)
+        compress = should_compress(p)
+        print(f"  {p.name:30s} type={file_type:20s} compress={compress}")

--- a/.agents/skills/caveman-compress/scripts/validate.py
+++ b/.agents/skills/caveman-compress/scripts/validate.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+import re
+from pathlib import Path
+
+URL_REGEX = re.compile(r"https?://[^\s)]+")
+FENCE_OPEN_REGEX = re.compile(r"^(\s{0,3})(`{3,}|~{3,})(.*)$")
+HEADING_REGEX = re.compile(r"^(#{1,6})\s+(.*)", re.MULTILINE)
+BULLET_REGEX = re.compile(r"^\s*[-*+]\s+", re.MULTILINE)
+
+# crude but effective path detection
+# Requires either a path prefix (./ ../ / or drive letter) or a slash/backslash within the match
+PATH_REGEX = re.compile(r"(?:\./|\.\./|/|[A-Za-z]:\\)[\w\-/\\\.]+|[\w\-\.]+[/\\][\w\-/\\\.]+")
+
+
+class ValidationResult:
+    def __init__(self):
+        self.is_valid = True
+        self.errors = []
+        self.warnings = []
+
+    def add_error(self, msg):
+        self.is_valid = False
+        self.errors.append(msg)
+
+    def add_warning(self, msg):
+        self.warnings.append(msg)
+
+
+def read_file(path: Path) -> str:
+    return path.read_text(errors="ignore")
+
+
+# ---------- Extractors ----------
+
+
+def extract_headings(text):
+    return [(level, title.strip()) for level, title in HEADING_REGEX.findall(text)]
+
+
+def extract_code_blocks(text):
+    """Line-based fenced code block extractor.
+
+    Handles ``` and ~~~ fences with variable length (CommonMark: closing
+    fence must use same char and be at least as long as opening). Supports
+    nested fences (e.g. an outer 4-backtick block wrapping inner 3-backtick
+    content).
+    """
+    blocks = []
+    lines = text.split("\n")
+    i = 0
+    n = len(lines)
+    while i < n:
+        m = FENCE_OPEN_REGEX.match(lines[i])
+        if not m:
+            i += 1
+            continue
+        fence_char = m.group(2)[0]
+        fence_len = len(m.group(2))
+        open_line = lines[i]
+        block_lines = [open_line]
+        i += 1
+        closed = False
+        while i < n:
+            close_m = FENCE_OPEN_REGEX.match(lines[i])
+            if (
+                close_m
+                and close_m.group(2)[0] == fence_char
+                and len(close_m.group(2)) >= fence_len
+                and close_m.group(3).strip() == ""
+            ):
+                block_lines.append(lines[i])
+                closed = True
+                i += 1
+                break
+            block_lines.append(lines[i])
+            i += 1
+        if closed:
+            blocks.append("\n".join(block_lines))
+        # Unclosed fences are silently skipped — they indicate malformed markdown
+        # and including them would cause false-positive validation failures.
+    return blocks
+
+
+def extract_urls(text):
+    return set(URL_REGEX.findall(text))
+
+
+def extract_paths(text):
+    return set(PATH_REGEX.findall(text))
+
+
+def count_bullets(text):
+    return len(BULLET_REGEX.findall(text))
+
+
+# ---------- Validators ----------
+
+
+def validate_headings(orig, comp, result):
+    h1 = extract_headings(orig)
+    h2 = extract_headings(comp)
+
+    if len(h1) != len(h2):
+        result.add_error(f"Heading count mismatch: {len(h1)} vs {len(h2)}")
+
+    if h1 != h2:
+        result.add_warning("Heading text/order changed")
+
+
+def validate_code_blocks(orig, comp, result):
+    c1 = extract_code_blocks(orig)
+    c2 = extract_code_blocks(comp)
+
+    if c1 != c2:
+        result.add_error("Code blocks not preserved exactly")
+
+
+def validate_urls(orig, comp, result):
+    u1 = extract_urls(orig)
+    u2 = extract_urls(comp)
+
+    if u1 != u2:
+        result.add_error(f"URL mismatch: lost={u1 - u2}, added={u2 - u1}")
+
+
+def validate_paths(orig, comp, result):
+    p1 = extract_paths(orig)
+    p2 = extract_paths(comp)
+
+    if p1 != p2:
+        result.add_warning(f"Path mismatch: lost={p1 - p2}, added={p2 - p1}")
+
+
+def validate_bullets(orig, comp, result):
+    b1 = count_bullets(orig)
+    b2 = count_bullets(comp)
+
+    if b1 == 0:
+        return
+
+    diff = abs(b1 - b2) / b1
+
+    if diff > 0.15:
+        result.add_warning(f"Bullet count changed too much: {b1} -> {b2}")
+
+
+# ---------- Main ----------
+
+
+def validate(original_path: Path, compressed_path: Path) -> ValidationResult:
+    result = ValidationResult()
+
+    orig = read_file(original_path)
+    comp = read_file(compressed_path)
+
+    validate_headings(orig, comp, result)
+    validate_code_blocks(orig, comp, result)
+    validate_urls(orig, comp, result)
+    validate_paths(orig, comp, result)
+    validate_bullets(orig, comp, result)
+
+    return result
+
+
+# ---------- CLI ----------
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) != 3:
+        print("Usage: python validate.py <original> <compressed>")
+        sys.exit(1)
+
+    orig = Path(sys.argv[1]).resolve()
+    comp = Path(sys.argv[2]).resolve()
+
+    res = validate(orig, comp)
+
+    print(f"\nValid: {res.is_valid}")
+
+    if res.errors:
+        print("\nErrors:")
+        for e in res.errors:
+            print(f"  - {e}")
+
+    if res.warnings:
+        print("\nWarnings:")
+        for w in res.warnings:
+            print(f"  - {w}")

--- a/.agents/skills/caveman-help/SKILL.md
+++ b/.agents/skills/caveman-help/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: caveman-help
+description: >
+  Quick-reference card for all caveman modes, skills, and commands.
+  One-shot display, not a persistent mode. Trigger: /caveman-help,
+  "caveman help", "what caveman commands", "how do I use caveman".
+---
+
+# Caveman Help
+
+Display this reference card when invoked. One-shot — do NOT change mode, write flag files, or persist anything. Output in caveman style.
+
+## Modes
+
+| Mode | Trigger | What change |
+|------|---------|-------------|
+| **Lite** | `/caveman lite` | Drop filler. Keep sentence structure. |
+| **Full** | `/caveman` | Drop articles, filler, pleasantries, hedging. Fragments OK. Default. |
+| **Ultra** | `/caveman ultra` | Extreme compression. Bare fragments. Tables over prose. |
+| **Wenyan-Lite** | `/caveman wenyan-lite` | Classical Chinese style, light compression. |
+| **Wenyan-Full** | `/caveman wenyan` | Full 文言文. Maximum classical terseness. |
+| **Wenyan-Ultra** | `/caveman wenyan-ultra` | Extreme. Ancient scholar on a budget. |
+
+Mode stick until changed or session end.
+
+## Skills
+
+| Skill | Trigger | What it do |
+|-------|---------|-----------|
+| **caveman-commit** | `/caveman-commit` | Terse commit messages. Conventional Commits. ≤50 char subject. |
+| **caveman-review** | `/caveman-review` | One-line PR comments: `L42: bug: user null. Add guard.` |
+| **caveman-compress** | `/caveman:compress <file>` | Compress .md files to caveman prose. Saves ~46% input tokens. |
+| **caveman-help** | `/caveman-help` | This card. |
+
+## Deactivate
+
+Say "stop caveman" or "normal mode". Resume anytime with `/caveman`.
+
+## Configure Default Mode
+
+Default mode = `full`. Change it:
+
+**Environment variable** (highest priority):
+```bash
+export CAVEMAN_DEFAULT_MODE=ultra
+```
+
+**Config file** (`~/.config/caveman/config.json`):
+```json
+{ "defaultMode": "lite" }
+```
+
+Set `"off"` to disable auto-activation on session start. User can still activate manually with `/caveman`.
+
+Resolution: env var > config file > `full`.
+
+## More
+
+Full docs: https://github.com/JuliusBrussee/caveman

--- a/.agents/skills/caveman-review/SKILL.md
+++ b/.agents/skills/caveman-review/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: caveman-review
+description: >
+  Ultra-compressed code review comments. Cuts noise from PR feedback while preserving
+  the actionable signal. Each comment is one line: location, problem, fix. Use when user
+  says "review this PR", "code review", "review the diff", "/review", or invokes
+  /caveman-review. Auto-triggers when reviewing pull requests.
+---
+
+Write code review comments terse and actionable. One line per finding. Location, problem, fix. No throat-clearing.
+
+## Rules
+
+**Format:** `L<line>: <problem>. <fix>.` — or `<file>:L<line>: ...` when reviewing multi-file diffs.
+
+**Severity prefix (optional, when mixed):**
+- `🔴 bug:` — broken behavior, will cause incident
+- `🟡 risk:` — works but fragile (race, missing null check, swallowed error)
+- `🔵 nit:` — style, naming, micro-optim. Author can ignore
+- `❓ q:` — genuine question, not a suggestion
+
+**Drop:**
+- "I noticed that...", "It seems like...", "You might want to consider..."
+- "This is just a suggestion but..." — use `nit:` instead
+- "Great work!", "Looks good overall but..." — say it once at the top, not per comment
+- Restating what the line does — the reviewer can read the diff
+- Hedging ("perhaps", "maybe", "I think") — if unsure use `q:`
+
+**Keep:**
+- Exact line numbers
+- Exact symbol/function/variable names in backticks
+- Concrete fix, not "consider refactoring this"
+- The *why* if the fix isn't obvious from the problem statement
+
+## Examples
+
+❌ "I noticed that on line 42 you're not checking if the user object is null before accessing the email property. This could potentially cause a crash if the user is not found in the database. You might want to add a null check here."
+
+✅ `L42: 🔴 bug: user can be null after .find(). Add guard before .email.`
+
+❌ "It looks like this function is doing a lot of things and might benefit from being broken up into smaller functions for readability."
+
+✅ `L88-140: 🔵 nit: 50-line fn does 4 things. Extract validate/normalize/persist.`
+
+❌ "Have you considered what happens if the API returns a 429? I think we should probably handle that case."
+
+✅ `L23: 🟡 risk: no retry on 429. Wrap in withBackoff(3).`
+
+## Auto-Clarity
+
+Drop terse mode for: security findings (CVE-class bugs need full explanation + reference), architectural disagreements (need rationale, not just a one-liner), and onboarding contexts where the author is new and needs the "why". In those cases write a normal paragraph, then resume terse for the rest.
+
+## Boundaries
+
+Reviews only — does not write the code fix, does not approve/request-changes, does not run linters. Output the comment(s) ready to paste into the PR. "stop caveman-review" or "normal mode": revert to verbose review style.

--- a/.agents/skills/caveman/SKILL.md
+++ b/.agents/skills/caveman/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: caveman
+description: >
+  Ultra-compressed communication mode. Cuts token usage ~75% by speaking like caveman
+  while keeping full technical accuracy. Supports intensity levels: lite, full (default), ultra,
+  wenyan-lite, wenyan-full, wenyan-ultra.
+  Use when user says "caveman mode", "talk like caveman", "use caveman", "less tokens",
+  "be brief", or invokes /caveman. Also auto-triggers when token efficiency is requested.
+---
+
+Respond terse like smart caveman. All technical substance stay. Only fluff die.
+
+## Persistence
+
+ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".
+
+Default: **full**. Switch: `/caveman lite|full|ultra`.
+
+## Rules
+
+Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.
+
+Pattern: `[thing] [action] [reason]. [next step].`
+
+Not: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
+Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
+
+## Intensity
+
+| Level | What change |
+|-------|------------|
+| **lite** | No filler/hedging. Keep articles + full sentences. Professional but tight |
+| **full** | Drop articles, fragments OK, short synonyms. Classic caveman |
+| **ultra** | Abbreviate (DB/auth/config/req/res/fn/impl), strip conjunctions, arrows for causality (X → Y), one word when one word enough |
+| **wenyan-lite** | Semi-classical. Drop filler/hedging but keep grammar structure, classical register |
+| **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
+| **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
+
+Example — "Why React component re-render?"
+- lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
+- full: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
+- ultra: "Inline obj prop → new ref → re-render. `useMemo`."
+- wenyan-lite: "組件頻重繪，以每繪新生對象參照故。以 useMemo 包之。"
+- wenyan-full: "物出新參照，致重繪。useMemo .Wrap之。"
+- wenyan-ultra: "新參照→重繪。useMemo Wrap。"
+
+Example — "Explain database connection pooling."
+- lite: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
+- full: "Pool reuse open DB connections. No new connection per request. Skip handshake overhead."
+- ultra: "Pool = reuse DB conn. Skip handshake → fast under load."
+- wenyan-full: "池reuse open connection。不每req新開。skip handshake overhead。"
+- wenyan-ultra: "池reuse conn。skip handshake → fast。"
+
+## Auto-Clarity
+
+Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user asks to clarify or repeats question. Resume caveman after clear part done.
+
+Example — destructive op:
+> **Warning:** This will permanently delete all rows in the `users` table and cannot be undone.
+> ```sql
+> DROP TABLE users;
+> ```
+> Caveman resume. Verify backup exist first.
+
+## Boundaries
+
+Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,63 @@
+# Copilot Instructions for Snowbird
+
+Snowbird is a Terraform/Permifrost-like CLI tool for declaratively managing Snowflake resources and grants. Users define desired state in a `snowflake.yml` config file, and Snowbird generates and optionally executes the SQL to converge Snowflake to that state.
+
+## Build, Test, and Lint
+
+```shell
+# Set up virtual environment with dev dependencies
+make install
+
+# Run the full test suite
+pytest tests
+
+# Run a single test
+pytest tests/test_execution_plan.py::test_function_name
+
+# Formatting (available as dev dependencies)
+black .
+isort .
+
+# Regenerate COMMANDS.md and REFERENCES.md after schema or CLI changes
+make docs
+```
+
+The CI pipeline (`.github/workflows/test.yaml`) runs `pytest tests` on every push.
+
+Root-level `test*.py` files are ad-hoc exploration scripts that hit a live Snowflake instance — they are not part of the pytest suite.
+
+## Architecture
+
+### CLI → Plan → Apply flow
+
+1. **`snowbird/main.py`** — Click CLI entry point with three commands: `plan`, `apply`, and `save state`.
+2. **`snowbird/plan.py`** — The core module. `load_config()` reads the YAML config (lowercasing the entire content on load). `execution_plan()` computes the desired SQL statements by diffing config against current state.
+3. **`snowbird/state.py`** — Fetches current Snowflake state using `SHOW` queries (databases, warehouses, schemas, users, roles, grants, network policies).
+4. **`snowbird/utils.py`** — Snowflake connection helper (`snowflake_cursor()`) and progress/spinner display.
+
+### SQL generation
+
+SQL statements are generated using **Jinja2 templates defined as string constants** inside `plan.py`. There are no external template files. The generated SQL is normalized by `_trim_sql_statements()`.
+
+### Role-based execution phases
+
+Generated SQL is organized by Snowflake role:
+- **`sysadmin`** — databases, schemas, warehouses
+- **`securityadmin`** — network policies
+- **`useradmin`** — users, roles, grants
+
+Each phase begins with an explicit `USE ROLE` statement.
+
+### State comparison
+
+`execution_plan(config, state)` diffs the desired config against current Snowflake state. Only the delta is emitted as SQL. Running with `--stateless` skips state comparison and generates all statements unconditionally.
+
+## Key Conventions
+
+- **Case-insensitive everywhere**: Config YAML is lowercased on load (`yaml.safe_load(content.lower())`). State comparisons normalize to lowercase. This is a core design decision.
+- **SQL-first testing**: Tests assert on exact SQL string output from `execution_plan()`, not on intermediate data structures.
+- **Functional style with dicts**: No rich domain model classes — config and state are plain dicts, processed by functions.
+- **Internal helpers use `_` prefix**: e.g., `_database_state()`, `_trim_sql_statements()`.
+- **`sysadmin` is auto-added**: All role grants automatically include `sysadmin` — this is enforced in `execution_plan()`.
+- **Config schema**: Defined in `snowflake.schema.json`. Additional properties are disallowed. See `REFERENCES.md` for human-readable docs.
+- **Versioning**: Version number lives in `setup.py`. Releases follow semver via `make release` which tags and creates a GitHub Release.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -61,3 +61,12 @@ Each phase begins with an explicit `USE ROLE` statement.
 - **`sysadmin` is auto-added**: All role grants automatically include `sysadmin` — this is enforced in `execution_plan()`.
 - **Config schema**: Defined in `snowflake.schema.json`. Additional properties are disallowed. See `REFERENCES.md` for human-readable docs.
 - **Versioning**: Version number lives in `setup.py`. Releases follow semver via `make release` which tags and creates a GitHub Release.
+
+## Communication Style
+
+Always use caveman skills when applicable:
+
+- **caveman** — All responses in caveman mode (full intensity by default)
+- **caveman-commit** — Generate commit messages in caveman style
+- **caveman-review** — Code reviews in caveman style
+- **caveman-compress** — Compress memory/instruction files in caveman format

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="snowbird",
-    version="0.5.6",
+    version="0.6.0",
     description=("Snowbird helps configure Snowflake resources for dataproducts"),
     # package_dir={"": "inbound"},
     packages=find_packages(include=("snowbird/*,")),

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "skills": {
+    "caveman": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "computedHash": "a818cdc41dcfaa50dd891c5cb5e5705968338de02e7e37949ca56e8c30ad4176"
+    },
+    "caveman-commit": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "computedHash": "76994afc39b68f4dbe098df76262b68d9928a23ee0f6aaebb11ba0e0f55bfa13"
+    },
+    "caveman-compress": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "computedHash": "300fb8578258161e1752a2a4142a7e9ff178c960bcb83b84422e2987421f33bf"
+    },
+    "caveman-help": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "computedHash": "3cd5f7d3f88c8ef7b16a6555dc61f5a11b14151386697609ab6887ab8b5f059d"
+    },
+    "caveman-review": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "computedHash": "1dc59e7e896bc9dd449e43116c4c8b2e656b88c3370df91848330c17347af3d0"
+    }
+}

--- a/snowbird/main.py
+++ b/snowbird/main.py
@@ -143,8 +143,36 @@ def plan(config, silent, state, stateless, print_execution_plan):
 
         click.echo(f"Grant or revoke:")
         click.echo("----------------")
-        total_grants = len(grant_selects) + len(grant_select_on_objects) + len(grant_create) + len(grant_roles) + len(grant_users) + len(grant_warehouses) + len(grant_databases) + len(grant_schemas)
-        total_revokes = len(revoke_roles) + len(revoke_users) + len(revoke_warehouses) + len(revoke_databases) + len(revoke_schemas) + len(revoke_selects) + len(revoke_select_on_objects) + len(revoke_create)
+        total_grants = sum(
+            map(
+                len,
+                [
+                    grant_selects,
+                    grant_select_on_objects,
+                    grant_create,
+                    grant_roles,
+                    grant_users,
+                    grant_warehouses,
+                    grant_databases,
+                    grant_schemas,
+                ],
+            )
+        )
+        total_revokes = sum(
+            map(
+                len,
+                [
+                    revoke_roles,
+                    revoke_users,
+                    revoke_warehouses,
+                    revoke_databases,
+                    revoke_schemas,
+                    revoke_selects,
+                    revoke_select_on_objects,
+                    revoke_create,
+                ],
+            )
+        )
         click.echo(
             "Total:".ljust(20)
             + f"{str(total_grants).rjust(2)} grant, {str(total_revokes).rjust(3)} revoke\n"

--- a/snowbird/main.py
+++ b/snowbird/main.py
@@ -80,9 +80,16 @@ def plan(config, silent, state, stateless, print_execution_plan):
     grant_roles = plan_overview.get("grant_roles", [])
     grant_users = plan_overview.get("grant_users", [])
     grant_warehouses = plan_overview.get("grant_warehouses", [])
+    grant_databases = plan_overview.get("grant_databases", [])
+    grant_schemas = plan_overview.get("grant_schemas", [])
     revoke_roles = plan_overview.get("revoke_roles", [])
     revoke_users = plan_overview.get("revoke_users", [])
     revoke_warehouses = plan_overview.get("revoke_warehouses", [])
+    revoke_databases = plan_overview.get("revoke_databases", [])
+    revoke_schemas = plan_overview.get("revoke_schemas", [])
+    revoke_selects = plan_overview.get("revoke_selects", [])
+    revoke_select_on_objects = plan_overview.get("revoke_select_on_objects", [])
+    revoke_create = plan_overview.get("revoke_create", [])
 
     if silent == False:
         click.echo("\nCreate or modify:")
@@ -136,8 +143,8 @@ def plan(config, silent, state, stateless, print_execution_plan):
 
         click.echo(f"Grant or revoke:")
         click.echo("----------------")
-        total_grants = len(grant_selects) + len(grant_select_on_objects) + len(grant_create) + len(grant_roles) + len(grant_users) + len(grant_warehouses)
-        total_revokes = len(revoke_roles) + len(revoke_users) + len(revoke_warehouses)
+        total_grants = len(grant_selects) + len(grant_select_on_objects) + len(grant_create) + len(grant_roles) + len(grant_users) + len(grant_warehouses) + len(grant_databases) + len(grant_schemas)
+        total_revokes = len(revoke_roles) + len(revoke_users) + len(revoke_warehouses) + len(revoke_databases) + len(revoke_schemas) + len(revoke_selects) + len(revoke_select_on_objects) + len(revoke_create)
         click.echo(
             "Total:".ljust(20)
             + f"{str(total_grants).rjust(2)} grant, {str(total_revokes).rjust(3)} revoke\n"
@@ -147,16 +154,24 @@ def plan(config, silent, state, stateless, print_execution_plan):
             + f"{str(len(grant_warehouses)).rjust(2)} grant, {str(len(revoke_warehouses)).rjust(3)} revoke"
         )
         click.echo(
+            "Databases:".ljust(20)
+            + f"{str(len(grant_databases)).rjust(2)} grant, {str(len(revoke_databases)).rjust(3)} revoke"
+        )
+        click.echo(
+            "Schemas:".ljust(20)
+            + f"{str(len(grant_schemas)).rjust(2)} grant, {str(len(revoke_schemas)).rjust(3)} revoke"
+        )
+        click.echo(
             "Read on schema:".ljust(20)
-            + f"{str(len(grant_selects)).rjust(2)} grant,   0 revoke"
+            + f"{str(len(grant_selects)).rjust(2)} grant, {str(len(revoke_selects)).rjust(3)} revoke"
         )
         click.echo(
             "Read on object:".ljust(20)
-            + f"{str(len(grant_select_on_objects)).rjust(2)} grant,   0 revoke"
+            + f"{str(len(grant_select_on_objects)).rjust(2)} grant, {str(len(revoke_select_on_objects)).rjust(3)} revoke"
         )
         click.echo(
             "Write on schema:".ljust(20)
-            + f"{str(len(grant_create)).rjust(2)} grant,   0 revoke"
+            + f"{str(len(grant_create)).rjust(2)} grant, {str(len(revoke_create)).rjust(3)} revoke"
         )
         click.echo(
             "Role to role:".ljust(20)

--- a/snowbird/main.py
+++ b/snowbird/main.py
@@ -79,8 +79,10 @@ def plan(config, silent, state, stateless, print_execution_plan):
     grant_create = plan_overview.get("grant_create", [])
     grant_roles = plan_overview.get("grant_roles", [])
     grant_users = plan_overview.get("grant_users", [])
+    grant_warehouses = plan_overview.get("grant_warehouses", [])
     revoke_roles = plan_overview.get("revoke_roles", [])
     revoke_users = plan_overview.get("revoke_users", [])
+    revoke_warehouses = plan_overview.get("revoke_warehouses", [])
 
     if silent == False:
         click.echo("\nCreate or modify:")
@@ -134,9 +136,15 @@ def plan(config, silent, state, stateless, print_execution_plan):
 
         click.echo(f"Grant or revoke:")
         click.echo("----------------")
+        total_grants = len(grant_selects) + len(grant_select_on_objects) + len(grant_create) + len(grant_roles) + len(grant_users) + len(grant_warehouses)
+        total_revokes = len(revoke_roles) + len(revoke_users) + len(revoke_warehouses)
         click.echo(
             "Total:".ljust(20)
-            + f"{str(len(grant_selects) + len(grant_select_on_objects) + len(grant_create) + len(grant_roles) + len(grant_users)).rjust(2)} grant,   0 revoke\n"
+            + f"{str(total_grants).rjust(2)} grant, {str(total_revokes).rjust(3)} revoke\n"
+        )
+        click.echo(
+            "Warehouses:".ljust(20)
+            + f"{str(len(grant_warehouses)).rjust(2)} grant, {str(len(revoke_warehouses)).rjust(3)} revoke"
         )
         click.echo(
             "Read on schema:".ljust(20)

--- a/snowbird/plan.py
+++ b/snowbird/plan.py
@@ -640,12 +640,16 @@ def _grant_role_execution_plan(grants: list[dict], state: dict) -> list[str]:
             revoke_role_read_on_semantic_views_in_schema,
         ),
     ]
+    # Track (schema_path, role) pairs that need new future grants — these also
+    # need ALL grants to bootstrap existing objects in that schema.
+    schemas_needing_bootstrap: set[tuple[str, str]] = set()
     for schema_path, desired_roles in desired_future_read.items():
         database, schema = schema_path.split(".")
         future_schema_state = future_in_schemas_state.get(schema_path)
         for grant_on_type, grant_tmpl, revoke_future_tmpl, revoke_all_tmpl in future_grant_types:
             if future_schema_state is None:
                 for role in desired_roles:
+                    schemas_needing_bootstrap.add((schema_path, role))
                     execution_plan.add(
                         jinja_env.from_string(grant_tmpl).render(
                             role=role, database=database, schema=schema
@@ -656,9 +660,10 @@ def _grant_role_execution_plan(grants: list[dict], state: dict) -> list[str]:
                     g["grantee_name"].lower()
                     for g in future_schema_state
                     if g["privilege"].lower() == "select"
-                    and g["grant_on"].lower() == grant_on_type
+                    and g["grant_on"].lower().replace("_", " ") == grant_on_type
                 }
                 for role in desired_roles - actual_roles:
+                    schemas_needing_bootstrap.add((schema_path, role))
                     execution_plan.add(
                         jinja_env.from_string(grant_tmpl).render(
                             role=role, database=database, schema=schema
@@ -775,8 +780,10 @@ def _grant_role_execution_plan(grants: list[dict], state: dict) -> list[str]:
         to_roles = grant.get("to_roles", [])
         to_users = grant.get("to_users", [])
 
-        # Always re-emit ALL grants (idempotent, covers existing objects)
+        # Emit ALL grants only when bootstrapping (future grants are being newly added)
         for full_schema_path in read_on_schemas:
+            if (full_schema_path, role) not in schemas_needing_bootstrap:
+                continue
             database, schema = full_schema_path.split(".")
             execution_plan.add(
                 jinja_env.from_string(grant_role_read_on_tables_in_schema).render(

--- a/snowbird/plan.py
+++ b/snowbird/plan.py
@@ -126,7 +126,7 @@ grant_role_read_on_dynamic_tables_in_schema = """
 revoke_role_read_on_dynamic_tables_in_schema = """
     revoke select on all dynamic tables in schema {{ database }}.{{ schema }} from role {{ role }}
 """
-grant_role_future_read_on_dynamic_tabbles_in_schema = """
+grant_role_future_read_on_dynamic_tables_in_schema = """
     grant select on future dynamic tables in schema {{ database }}.{{ schema }} to role {{ role }}
 """
 revoke_role_future_read_on_dynamic_tables_in_schema = """
@@ -629,7 +629,7 @@ def _grant_role_execution_plan(grants: list[dict], state: dict) -> list[str]:
         ),
         (
             "dynamic table",
-            grant_role_future_read_on_dynamic_tabbles_in_schema,
+            grant_role_future_read_on_dynamic_tables_in_schema,
             revoke_role_future_read_on_dynamic_tables_in_schema,
             revoke_role_read_on_dynamic_tables_in_schema,
         ),

--- a/snowbird/plan.py
+++ b/snowbird/plan.py
@@ -68,6 +68,9 @@ alter_network_policy = """
 grant_role_usage_on_warehouse = """
     grant usage on warehouse {{ warehouse }} to role {{ role }}
 """
+revoke_role_usage_on_warehouse = """
+    revoke usage on warehouse {{ warehouse }} from role {{ role }}
+"""
 grant_role_usage_on_database = """
     grant usage on database {{ database }} to role {{ role }}
 """
@@ -343,20 +346,53 @@ def _grant_role_execution_plan(grants: list[dict], state: dict) -> list[str]:
     if len(grants) == 0:
         return []
     execution_plan = set()
+
+    # Aggregate desired warehouse grants: {warehouse: set(roles)}
+    desired_warehouse_roles: dict[str, set[str]] = {}
     for grant in grants:
         role = grant["role"]
-        warehouses = grant.get("warehouses", [])
+        for warehouse in grant.get("warehouses", []):
+            if warehouse not in desired_warehouse_roles:
+                desired_warehouse_roles[warehouse] = set()
+            desired_warehouse_roles[warehouse].add(role)
+
+    # Diff warehouse grants against state
+    on_warehouses_state = state.get("on_warehouses", {})
+    for warehouse, desired_roles in desired_warehouse_roles.items():
+        warehouse_grant_state = on_warehouses_state.get(warehouse)
+        if warehouse_grant_state is None:
+            # No state — grant unconditionally
+            for role in desired_roles:
+                stmt = jinja_env.from_string(grant_role_usage_on_warehouse).render(
+                    role=role, warehouse=warehouse
+                )
+                execution_plan.add(stmt)
+        else:
+            actual_roles = {
+                g["grantee_name"].lower()
+                for g in warehouse_grant_state
+                if g["privilege"].lower() == "usage"
+            }
+            # Grant missing
+            for role in desired_roles - actual_roles:
+                stmt = jinja_env.from_string(grant_role_usage_on_warehouse).render(
+                    role=role, warehouse=warehouse
+                )
+                execution_plan.add(stmt)
+            # Revoke extra
+            for role in actual_roles - desired_roles:
+                stmt = jinja_env.from_string(revoke_role_usage_on_warehouse).render(
+                    role=role, warehouse=warehouse
+                )
+                execution_plan.add(stmt)
+
+    for grant in grants:
+        role = grant["role"]
         read_on_schemas = grant.get("read_on_schemas", [])
         write_on_schemas = grant.get("write_on_schemas", [])
         read_on_objects = grant.get("read_on_objects", [])
         to_roles = grant.get("to_roles", [])
         to_users = grant.get("to_users", [])
-
-        for warehouse in warehouses:
-            grant_role_usage_on_warehouse_statement = jinja_env.from_string(
-                grant_role_usage_on_warehouse
-            ).render(role=role, warehouse=warehouse)
-            execution_plan.add(grant_role_usage_on_warehouse_statement)
 
         for full_schema_path in read_on_schemas:
             database, schema = full_schema_path.split(".")
@@ -820,6 +856,12 @@ def overview(execution_plan: dict) -> dict:
     grant_create = [s for s in execution_plan if "grant create table" in s]
     grant_roles = [s for s in execution_plan if "grant role" in s and "to role" in s]
     grant_users = [s for s in execution_plan if "grant role" in s and "to user" in s]
+    grant_warehouses = [
+        s for s in execution_plan if "grant usage on warehouse" in s
+    ]
+    revoke_warehouses = [
+        s for s in execution_plan if "revoke usage on warehouse" in s
+    ]
 
     revoke_roles = [
         s for s in execution_plan if "revoke role" in s and "from role" in s
@@ -845,6 +887,8 @@ def overview(execution_plan: dict) -> dict:
         "grant_create": grant_create,
         "grant_roles": grant_roles,
         "grant_users": grant_users,
+        "grant_warehouses": grant_warehouses,
+        "revoke_warehouses": revoke_warehouses,
         "revoke_roles": revoke_roles,
         "revoke_users": revoke_users,
     }

--- a/snowbird/plan.py
+++ b/snowbird/plan.py
@@ -35,6 +35,10 @@ create_role = """
     create role if not exists {{ role }}
 """
 
+transfer_ownership = """
+    grant ownership on {{ resource_type }} {{ name }} to role {{ role }} copy current grants
+"""
+
 create_network_policy = """
     create network policy if not exists {{ name }}
         allowed_network_rule_list = (
@@ -71,41 +75,80 @@ grant_role_usage_on_warehouse = """
 revoke_role_usage_on_warehouse = """
     revoke usage on warehouse {{ warehouse }} from role {{ role }}
 """
+revoke_privilege_on_resource = """
+    revoke {{ privilege }} on {{ resource_type }} {{ name }} from role {{ role }}
+"""
 grant_role_usage_on_database = """
     grant usage on database {{ database }} to role {{ role }}
+"""
+revoke_role_usage_on_database = """
+    revoke usage on database {{ database }} from role {{ role }}
 """
 grant_role_usage_on_schema = """
     grant usage on schema {{ database }}.{{ schema }} to role {{ role }}
 """
+revoke_role_usage_on_schema = """
+    revoke usage on schema {{ database }}.{{ schema }} from role {{ role }}
+"""
 grant_role_create_on_schema = """
     grant create {{ type }} on schema {{ database }}.{{ schema }} to role {{ role }}
+"""
+revoke_role_create_on_schema = """
+    revoke create {{ type }} on schema {{ database }}.{{ schema }} from role {{ role }}
 """
 grant_role_read_on_tables_in_schema = """
     grant select on all tables in schema {{ database }}.{{ schema }} to role {{ role }}
 """
+revoke_role_read_on_tables_in_schema = """
+    revoke select on all tables in schema {{ database }}.{{ schema }} from role {{ role }}
+"""
 grant_role_future_read_on_tables_in_schema = """
     grant select on future tables in schema {{ database }}.{{ schema }} to role {{ role }}
+"""
+revoke_role_future_read_on_tables_in_schema = """
+    revoke select on future tables in schema {{ database }}.{{ schema }} from role {{ role }}
 """
 grant_role_read_on_views_in_schema = """
     grant select on all views in schema {{ database }}.{{ schema }} to role {{ role }}
 """
+revoke_role_read_on_views_in_schema = """
+    revoke select on all views in schema {{ database }}.{{ schema }} from role {{ role }}
+"""
 grant_role_future_read_on_views_in_schema = """
     grant select on future views in schema {{ database }}.{{ schema }} to role {{ role }}
+"""
+revoke_role_future_read_on_views_in_schema = """
+    revoke select on future views in schema {{ database }}.{{ schema }} from role {{ role }}
 """
 grant_role_read_on_dynamic_tables_in_schema = """
     grant select on all dynamic tables in schema {{ database }}.{{ schema }} to role {{ role }}
 """
+revoke_role_read_on_dynamic_tables_in_schema = """
+    revoke select on all dynamic tables in schema {{ database }}.{{ schema }} from role {{ role }}
+"""
 grant_role_future_read_on_dynamic_tabbles_in_schema = """
     grant select on future dynamic tables in schema {{ database }}.{{ schema }} to role {{ role }}
+"""
+revoke_role_future_read_on_dynamic_tables_in_schema = """
+    revoke select on future dynamic tables in schema {{ database }}.{{ schema }} from role {{ role }}
 """
 grant_role_read_on_semantic_views_in_schema = """
     grant select on all semantic views in schema {{ database }}.{{ schema }} to role {{ role }}
 """
+revoke_role_read_on_semantic_views_in_schema = """
+    revoke select on all semantic views in schema {{ database }}.{{ schema }} from role {{ role }}
+"""
 grant_role_future_read_on_semantic_views_in_schema = """
     grant select on future semantic views in schema {{ database }}.{{ schema }} to role {{ role }}
 """
+revoke_role_future_read_on_semantic_views_in_schema = """
+    revoke select on future semantic views in schema {{ database }}.{{ schema }} from role {{ role }}
+"""
 grant_role_select_on_object = """
     grant select on {{ object_type }} {{ database }}.{{ schema }}.{{ object_name }} to role {{ role }}
+"""
+revoke_role_select_on_object = """
+    revoke select on {{ object_type }} {{ database }}.{{ schema }}.{{ object_name }} from role {{ role }}
 """
 grant_role_to_user = """
     grant role {{ role }} to user "{{ to_user.upper() }}"
@@ -203,6 +246,13 @@ def _create_databases_execution_plan(databases: list[dict], state: dict) -> list
             ).render(database=db_name, retention_days=db_data_retention_time_in_days)
             execution_plan.append(alter_database_data_retention_statement)
 
+        if db_state.get("owner") and db_state["owner"] != "sysadmin":
+            execution_plan.append(
+                jinja_env.from_string(transfer_ownership).render(
+                    resource_type="database", name=db_name, role="sysadmin"
+                )
+            )
+
     return execution_plan
 
 
@@ -264,6 +314,15 @@ def _create_schema_execution_plan(databases: list[dict], state: dict) -> list[st
                     retention_days=schema_data_retention_time_in_days,
                 )
                 execution_plan.append(alter_schema_data_retention_statement)
+
+            if schema_state.get("owner") and schema_state["owner"] != "sysadmin":
+                execution_plan.append(
+                    jinja_env.from_string(transfer_ownership).render(
+                        resource_type="schema",
+                        name=full_schema_name,
+                        role="sysadmin",
+                    )
+                )
     return execution_plan
 
 
@@ -292,6 +351,15 @@ def _create_warehouses_execution_plan(warehouses: list[dict], state: dict) -> li
                 warehouse=warehouse_name, size=warehouse_size
             )
             execution_plan.append(alter_warehouse_statement)
+
+        if warehouse_state.get("owner") and warehouse_state["owner"] != "sysadmin":
+            execution_plan.append(
+                jinja_env.from_string(transfer_ownership).render(
+                    resource_type="warehouse",
+                    name=warehouse_name,
+                    role="sysadmin",
+                )
+            )
     return execution_plan
 
 
@@ -339,6 +407,12 @@ def _create_roles_execution_plan(roles: list[dict], state: dict) -> list[str]:
                 role=role_name
             )
             execution_plan.append(create_role_statement)
+        elif role_state.get("owner") and role_state["owner"] != "useradmin":
+            execution_plan.append(
+                jinja_env.from_string(transfer_ownership).render(
+                    resource_type="role", name=role_name, role="useradmin"
+                )
+            )
     return execution_plan
 
 
@@ -347,21 +421,64 @@ def _grant_role_execution_plan(grants: list[dict], state: dict) -> list[str]:
         return []
     execution_plan = set()
 
-    # Aggregate desired warehouse grants: {warehouse: set(roles)}
+    # === Phase 1: Aggregate desired grants across all config entries ===
+
     desired_warehouse_roles: dict[str, set[str]] = {}
+    desired_database_roles: dict[str, set[str]] = {}
+    desired_schema_roles: dict[str, set[str]] = {}
+    desired_future_read: dict[str, set[str]] = {}
+    desired_create: dict[str, set[str]] = {}
+    # {config_key: {"roles": set, "sf_type": str, "db": str, "schema": str, "name": str}}
+    desired_object_read: dict[str, dict] = {}
+
     for grant in grants:
         role = grant["role"]
-        for warehouse in grant.get("warehouses", []):
-            if warehouse not in desired_warehouse_roles:
-                desired_warehouse_roles[warehouse] = set()
-            desired_warehouse_roles[warehouse].add(role)
 
-    # Diff warehouse grants against state
+        for warehouse in grant.get("warehouses", []):
+            desired_warehouse_roles.setdefault(warehouse, set()).add(role)
+
+        for schema_path in grant.get("read_on_schemas", []):
+            database = schema_path.split(".")[0]
+            desired_database_roles.setdefault(database, set()).add(role)
+            desired_schema_roles.setdefault(schema_path, set()).add(role)
+            desired_future_read.setdefault(schema_path, set()).add(role)
+
+        for schema_path in grant.get("write_on_schemas", []):
+            database = schema_path.split(".")[0]
+            desired_database_roles.setdefault(database, set()).add(role)
+            desired_schema_roles.setdefault(schema_path, set()).add(role)
+            desired_create.setdefault(schema_path, set()).add(role)
+
+        for object_entry in grant.get("read_on_objects", []):
+            object_type, object_name = _parse_object_type(object_entry)
+            parts = object_name.split(".")
+            if len(parts) != 3:
+                raise ValueError(
+                    f"Invalid object path {object_name}, must be in the format database.schema.object"
+                )
+            database, schema, name = parts
+            config_key = object_entry
+            desired_database_roles.setdefault(database, set()).add(role)
+            desired_schema_roles.setdefault(
+                f"{database}.{schema}", set()
+            ).add(role)
+            if config_key not in desired_object_read:
+                desired_object_read[config_key] = {
+                    "roles": set(),
+                    "sf_type": object_type,
+                    "db": database,
+                    "schema": schema,
+                    "name": name,
+                }
+            desired_object_read[config_key]["roles"].add(role)
+
+    # === Phase 2: Stateful diffing ===
+
+    # --- Warehouse USAGE ---
     on_warehouses_state = state.get("on_warehouses", {})
     for warehouse, desired_roles in desired_warehouse_roles.items():
         warehouse_grant_state = on_warehouses_state.get(warehouse)
         if warehouse_grant_state is None:
-            # No state — grant unconditionally
             for role in desired_roles:
                 stmt = jinja_env.from_string(grant_role_usage_on_warehouse).render(
                     role=role, warehouse=warehouse
@@ -373,148 +490,314 @@ def _grant_role_execution_plan(grants: list[dict], state: dict) -> list[str]:
                 for g in warehouse_grant_state
                 if g["privilege"].lower() == "usage"
             }
-            # Grant missing
             for role in desired_roles - actual_roles:
                 stmt = jinja_env.from_string(grant_role_usage_on_warehouse).render(
                     role=role, warehouse=warehouse
                 )
                 execution_plan.add(stmt)
-            # Revoke extra
             for role in actual_roles - desired_roles:
                 stmt = jinja_env.from_string(revoke_role_usage_on_warehouse).render(
                     role=role, warehouse=warehouse
                 )
                 execution_plan.add(stmt)
+            # Revoke unmanaged privileges (anything that isn't USAGE or OWNERSHIP)
+            for g in warehouse_grant_state:
+                priv = g["privilege"].lower()
+                if priv not in ("usage", "ownership"):
+                    execution_plan.add(
+                        jinja_env.from_string(revoke_privilege_on_resource).render(
+                            privilege=priv,
+                            resource_type="warehouse",
+                            name=warehouse,
+                            role=g["grantee_name"].lower(),
+                        )
+                    )
 
+    # --- Database USAGE ---
+    on_databases_state = state.get("on_databases", {})
+    for database, desired_roles in desired_database_roles.items():
+        db_grant_state = on_databases_state.get(database)
+        if db_grant_state is None:
+            for role in desired_roles:
+                execution_plan.add(
+                    jinja_env.from_string(grant_role_usage_on_database).render(
+                        role=role, database=database
+                    )
+                )
+        else:
+            actual_roles = {
+                g["grantee_name"].lower()
+                for g in db_grant_state
+                if g["privilege"].lower() == "usage"
+            }
+            for role in desired_roles - actual_roles:
+                execution_plan.add(
+                    jinja_env.from_string(grant_role_usage_on_database).render(
+                        role=role, database=database
+                    )
+                )
+            for role in actual_roles - desired_roles:
+                execution_plan.add(
+                    jinja_env.from_string(revoke_role_usage_on_database).render(
+                        role=role, database=database
+                    )
+                )
+            # Revoke unmanaged privileges
+            for g in db_grant_state:
+                priv = g["privilege"].lower()
+                if priv not in ("usage", "ownership"):
+                    execution_plan.add(
+                        jinja_env.from_string(revoke_privilege_on_resource).render(
+                            privilege=priv,
+                            resource_type="database",
+                            name=database,
+                            role=g["grantee_name"].lower(),
+                        )
+                    )
+
+    # --- Schema USAGE ---
+    on_schemas_state = state.get("on_schemas", {})
+    create_types = [
+        "table",
+        "view",
+        "dynamic table",
+        "semantic view",
+        "task",
+        "alert",
+        "masking policy",
+        "row access policy",
+        "procedure",
+    ]
+    for schema_path, desired_roles in desired_schema_roles.items():
+        database, schema = schema_path.split(".")
+        schema_grant_state = on_schemas_state.get(schema_path)
+        if schema_grant_state is None:
+            for role in desired_roles:
+                execution_plan.add(
+                    jinja_env.from_string(grant_role_usage_on_schema).render(
+                        role=role, database=database, schema=schema
+                    )
+                )
+        else:
+            actual_roles = {
+                g["grantee_name"].lower()
+                for g in schema_grant_state
+                if g["privilege"].lower() == "usage"
+            }
+            for role in desired_roles - actual_roles:
+                execution_plan.add(
+                    jinja_env.from_string(grant_role_usage_on_schema).render(
+                        role=role, database=database, schema=schema
+                    )
+                )
+            for role in actual_roles - desired_roles:
+                execution_plan.add(
+                    jinja_env.from_string(revoke_role_usage_on_schema).render(
+                        role=role, database=database, schema=schema
+                    )
+                )
+            # Revoke unmanaged privileges (not USAGE, not CREATE types, not OWNERSHIP)
+            managed_schema_privs = {"usage", "ownership"}
+            for ct in create_types:
+                managed_schema_privs.add(f"create {ct}")
+            for g in schema_grant_state:
+                priv = g["privilege"].lower()
+                if priv not in managed_schema_privs:
+                    execution_plan.add(
+                        jinja_env.from_string(revoke_privilege_on_resource).render(
+                            privilege=priv,
+                            resource_type="schema",
+                            name=schema_path,
+                            role=g["grantee_name"].lower(),
+                        )
+                    )
+
+    # --- Future read grants (read_on_schemas) ---
+    future_in_schemas_state = state.get("future_in_schemas", {})
+    future_grant_types = [
+        (
+            "table",
+            grant_role_future_read_on_tables_in_schema,
+            revoke_role_future_read_on_tables_in_schema,
+            revoke_role_read_on_tables_in_schema,
+        ),
+        (
+            "view",
+            grant_role_future_read_on_views_in_schema,
+            revoke_role_future_read_on_views_in_schema,
+            revoke_role_read_on_views_in_schema,
+        ),
+        (
+            "dynamic table",
+            grant_role_future_read_on_dynamic_tabbles_in_schema,
+            revoke_role_future_read_on_dynamic_tables_in_schema,
+            revoke_role_read_on_dynamic_tables_in_schema,
+        ),
+        (
+            "semantic view",
+            grant_role_future_read_on_semantic_views_in_schema,
+            revoke_role_future_read_on_semantic_views_in_schema,
+            revoke_role_read_on_semantic_views_in_schema,
+        ),
+    ]
+    for schema_path, desired_roles in desired_future_read.items():
+        database, schema = schema_path.split(".")
+        future_schema_state = future_in_schemas_state.get(schema_path)
+        for grant_on_type, grant_tmpl, revoke_future_tmpl, revoke_all_tmpl in future_grant_types:
+            if future_schema_state is None:
+                for role in desired_roles:
+                    execution_plan.add(
+                        jinja_env.from_string(grant_tmpl).render(
+                            role=role, database=database, schema=schema
+                        )
+                    )
+            else:
+                actual_roles = {
+                    g["grantee_name"].lower()
+                    for g in future_schema_state
+                    if g["privilege"].lower() == "select"
+                    and g["grant_on"].lower() == grant_on_type
+                }
+                for role in desired_roles - actual_roles:
+                    execution_plan.add(
+                        jinja_env.from_string(grant_tmpl).render(
+                            role=role, database=database, schema=schema
+                        )
+                    )
+                for role in actual_roles - desired_roles:
+                    execution_plan.add(
+                        jinja_env.from_string(revoke_future_tmpl).render(
+                            role=role, database=database, schema=schema
+                        )
+                    )
+                    # Also revoke on existing objects to clean up
+                    execution_plan.add(
+                        jinja_env.from_string(revoke_all_tmpl).render(
+                            role=role, database=database, schema=schema
+                        )
+                    )
+
+    # --- CREATE grants (write_on_schemas) ---
+    for schema_path, desired_roles in desired_create.items():
+        database, schema = schema_path.split(".")
+        schema_grant_state = on_schemas_state.get(schema_path)
+        for create_type in create_types:
+            privilege_name = f"create {create_type}"
+            if schema_grant_state is None:
+                for role in desired_roles:
+                    execution_plan.add(
+                        jinja_env.from_string(grant_role_create_on_schema).render(
+                            type=create_type,
+                            role=role,
+                            database=database,
+                            schema=schema,
+                        )
+                    )
+            else:
+                actual_roles = {
+                    g["grantee_name"].lower()
+                    for g in schema_grant_state
+                    if g["privilege"].lower() == privilege_name
+                }
+                for role in desired_roles - actual_roles:
+                    execution_plan.add(
+                        jinja_env.from_string(grant_role_create_on_schema).render(
+                            type=create_type,
+                            role=role,
+                            database=database,
+                            schema=schema,
+                        )
+                    )
+                for role in actual_roles - desired_roles:
+                    execution_plan.add(
+                        jinja_env.from_string(revoke_role_create_on_schema).render(
+                            type=create_type,
+                            role=role,
+                            database=database,
+                            schema=schema,
+                        )
+                    )
+
+    # --- Object SELECT grants (read_on_objects) ---
+    on_objects_state = state.get("on_objects", {})
+    for config_key, info in desired_object_read.items():
+        obj_state = on_objects_state.get(config_key)
+        explicitly_desired = info["roles"]
+        # Include roles from read_on_schemas for the containing schema
+        # to avoid revoking schema-level access
+        containing_schema = f"{info['db']}.{info['schema']}"
+        expanded_desired = explicitly_desired | desired_future_read.get(
+            containing_schema, set()
+        )
+
+        if obj_state is None:
+            for role in explicitly_desired:
+                execution_plan.add(
+                    jinja_env.from_string(grant_role_select_on_object).render(
+                        role=role,
+                        object_type=info["sf_type"],
+                        database=info["db"],
+                        schema=info["schema"],
+                        object_name=info["name"],
+                    )
+                )
+        else:
+            actual_roles = {
+                g["grantee_name"].lower()
+                for g in obj_state
+                if g["privilege"].lower() == "select"
+            }
+            for role in explicitly_desired - actual_roles:
+                execution_plan.add(
+                    jinja_env.from_string(grant_role_select_on_object).render(
+                        role=role,
+                        object_type=info["sf_type"],
+                        database=info["db"],
+                        schema=info["schema"],
+                        object_name=info["name"],
+                    )
+                )
+            for role in actual_roles - expanded_desired:
+                execution_plan.add(
+                    jinja_env.from_string(revoke_role_select_on_object).render(
+                        role=role,
+                        object_type=info["sf_type"],
+                        database=info["db"],
+                        schema=info["schema"],
+                        object_name=info["name"],
+                    )
+                )
+
+    # === Phase 3: Per-grant loop (ALL grants + to_roles/to_users) ===
     for grant in grants:
         role = grant["role"]
         read_on_schemas = grant.get("read_on_schemas", [])
-        write_on_schemas = grant.get("write_on_schemas", [])
-        read_on_objects = grant.get("read_on_objects", [])
         to_roles = grant.get("to_roles", [])
         to_users = grant.get("to_users", [])
 
+        # Always re-emit ALL grants (idempotent, covers existing objects)
         for full_schema_path in read_on_schemas:
             database, schema = full_schema_path.split(".")
-            grant_role_usage_on_database_statement = jinja_env.from_string(
-                grant_role_usage_on_database
-            ).render(role=role, database=database)
-            execution_plan.add(grant_role_usage_on_database_statement)
-
-            grant_role_usage_on_schema_statement = jinja_env.from_string(
-                grant_role_usage_on_schema
-            ).render(role=role, database=database, schema=schema)
-            execution_plan.add(grant_role_usage_on_schema_statement)
-
-            grant_role_read_on_schema_statement = jinja_env.from_string(
-                grant_role_read_on_tables_in_schema
-            ).render(role=role, database=database, schema=schema)
-            execution_plan.add(grant_role_read_on_schema_statement)
-
-            grant_role_future_read_on_schema_statement = jinja_env.from_string(
-                grant_role_future_read_on_tables_in_schema
-            ).render(role=role, database=database, schema=schema)
-            execution_plan.add(grant_role_future_read_on_schema_statement)
-
-            grant_role_read_on_views_in_schema_statement = jinja_env.from_string(
-                grant_role_read_on_views_in_schema
-            ).render(role=role, database=database, schema=schema)
-            execution_plan.add(grant_role_read_on_views_in_schema_statement)
-
-            grant_role_future_read_on_views_in_schema_statement = jinja_env.from_string(
-                grant_role_future_read_on_views_in_schema
-            ).render(role=role, database=database, schema=schema)
-            execution_plan.add(grant_role_future_read_on_views_in_schema_statement)
-
-            grant_role_read_on_dynamic_tables_in_schema_statement = (
+            execution_plan.add(
+                jinja_env.from_string(grant_role_read_on_tables_in_schema).render(
+                    role=role, database=database, schema=schema
+                )
+            )
+            execution_plan.add(
+                jinja_env.from_string(grant_role_read_on_views_in_schema).render(
+                    role=role, database=database, schema=schema
+                )
+            )
+            execution_plan.add(
                 jinja_env.from_string(
                     grant_role_read_on_dynamic_tables_in_schema
                 ).render(role=role, database=database, schema=schema)
             )
-            execution_plan.add(grant_role_read_on_dynamic_tables_in_schema_statement)
-
-            grant_role_future_read_on_dynamic_tables_in_schema_statement = (
-                jinja_env.from_string(
-                    grant_role_future_read_on_dynamic_tabbles_in_schema
-                ).render(role=role, database=database, schema=schema)
-            )
             execution_plan.add(
-                grant_role_future_read_on_dynamic_tables_in_schema_statement
-            )
-
-            grant_role_read_on_semantic_views_in_schema_statement = (
                 jinja_env.from_string(
                     grant_role_read_on_semantic_views_in_schema
                 ).render(role=role, database=database, schema=schema)
             )
-            execution_plan.add(grant_role_read_on_semantic_views_in_schema_statement)
-            grant_role_future_read_on_semantic_views_in_schema_statement = (
-                jinja_env.from_string(
-                    grant_role_future_read_on_semantic_views_in_schema
-                ).render(role=role, database=database, schema=schema)
-            )
-            execution_plan.add(
-                grant_role_future_read_on_semantic_views_in_schema_statement
-            )
-
-        for full_schema_path in write_on_schemas:
-            database, schema = full_schema_path.split(".")
-            grant_role_usage_on_database_statement = jinja_env.from_string(
-                grant_role_usage_on_database
-            ).render(role=role, database=database)
-            execution_plan.add(grant_role_usage_on_database_statement)
-
-            grant_role_usage_on_schema_statement = jinja_env.from_string(
-                grant_role_usage_on_schema
-            ).render(role=role, database=database, schema=schema)
-            execution_plan.add(grant_role_usage_on_schema_statement)
-
-            create_types = [
-                "table",
-                "view",
-                "dynamic table",
-                "semantic view",
-                "task",
-                "alert",
-                "masking policy",
-                "row access policy",
-                "procedure",
-            ]
-            for type in create_types:
-                grant_role_create_on_schema_statement = jinja_env.from_string(
-                    grant_role_create_on_schema
-                ).render(type=type, role=role, database=database, schema=schema)
-                execution_plan.add(grant_role_create_on_schema_statement)
-
-        for object_entry in read_on_objects:
-            object_type, object_name = _parse_object_type(object_entry)
-            parts = object_name.split(".")
-            if len(parts) != 3:
-                raise ValueError(
-                    f"Invalid object path {object_name}, must be in the format database.schema.object"
-                )
-            database, schema, name = parts
-
-            grant_role_usage_on_database_statement = jinja_env.from_string(
-                grant_role_usage_on_database
-            ).render(role=role, database=database)
-            execution_plan.add(grant_role_usage_on_database_statement)
-
-            grant_role_usage_on_schema_statement = jinja_env.from_string(
-                grant_role_usage_on_schema
-            ).render(role=role, database=database, schema=schema)
-            execution_plan.add(grant_role_usage_on_schema_statement)
-
-            grant_select_on_object_statement = jinja_env.from_string(
-                grant_role_select_on_object
-            ).render(
-                role=role,
-                object_type=object_type,
-                database=database,
-                schema=schema,
-                object_name=name,
-            )
-            execution_plan.add(grant_select_on_object_statement)
 
         # Grant and revoke roles to users and roles
         grant_of_role_state = state.get("of_roles", {}).get(role)
@@ -599,6 +882,7 @@ def _database_state(databases: list[dict], state: dict) -> dict:
         database["name"].lower(): {
             "data_retention_time_in_days": database["retention_time"],
             "transient": True if "transient" in database["options"].lower() else False,
+            "owner": database.get("owner", "").lower(),
         }
         for database in state["databases"]
         if database["name"].lower() in database_names
@@ -629,6 +913,7 @@ def _schema_state(databases: list[dict], state: dict) -> dict:
                             if "transient" in schema_state["options"].lower()
                             else False
                         ),
+                        "owner": schema_state.get("owner", "").lower(),
                         "schema": schema_state,
                     }
     return existing_state
@@ -646,6 +931,7 @@ def _warehouse_state(warehouses: list[dict], state: dict) -> dict:
             if warehouse_name == warehouse_state["name"].lower():
                 existing_state[warehouse_name] = {
                     "size": warehouse_state["size"].lower(),
+                    "owner": warehouse_state.get("owner", "").lower(),
                 }
     return existing_state
 
@@ -677,7 +963,9 @@ def _role_state(roles: list[dict], state: dict) -> dict:
         role_name = role["name"].lower()
         for role_state in state["roles"]:
             if role_name == role_state["name"].lower():
-                existing_state[role_name] = {}
+                existing_state[role_name] = {
+                    "owner": role_state.get("owner", "").lower(),
+                }
     return existing_state
 
 
@@ -853,15 +1141,34 @@ def overview(execution_plan: dict) -> dict:
 
     grant_selects = [s for s in execution_plan if "grant select on" in s and "in schema" in s]
     grant_select_on_objects = [s for s in execution_plan if "grant select on" in s and "in schema" not in s]
-    grant_create = [s for s in execution_plan if "grant create table" in s]
+    grant_create = [s for s in execution_plan if "grant create" in s]
     grant_roles = [s for s in execution_plan if "grant role" in s and "to role" in s]
     grant_users = [s for s in execution_plan if "grant role" in s and "to user" in s]
     grant_warehouses = [
         s for s in execution_plan if "grant usage on warehouse" in s
     ]
+    grant_databases = [
+        s for s in execution_plan if "grant usage on database" in s
+    ]
+    grant_schemas = [
+        s for s in execution_plan if "grant usage on schema" in s
+    ]
     revoke_warehouses = [
         s for s in execution_plan if "revoke usage on warehouse" in s
     ]
+    revoke_databases = [
+        s for s in execution_plan if "revoke usage on database" in s
+    ]
+    revoke_schemas = [
+        s for s in execution_plan if "revoke usage on schema" in s
+    ]
+    revoke_selects = [
+        s for s in execution_plan if "revoke select on" in s and "in schema" in s
+    ]
+    revoke_select_on_objects = [
+        s for s in execution_plan if "revoke select on" in s and "in schema" not in s
+    ]
+    revoke_create = [s for s in execution_plan if "revoke create" in s]
 
     revoke_roles = [
         s for s in execution_plan if "revoke role" in s and "from role" in s
@@ -888,7 +1195,14 @@ def overview(execution_plan: dict) -> dict:
         "grant_roles": grant_roles,
         "grant_users": grant_users,
         "grant_warehouses": grant_warehouses,
+        "grant_databases": grant_databases,
+        "grant_schemas": grant_schemas,
         "revoke_warehouses": revoke_warehouses,
+        "revoke_databases": revoke_databases,
+        "revoke_schemas": revoke_schemas,
+        "revoke_selects": revoke_selects,
+        "revoke_select_on_objects": revoke_select_on_objects,
+        "revoke_create": revoke_create,
         "revoke_roles": revoke_roles,
         "revoke_users": revoke_users,
     }

--- a/snowbird/state.py
+++ b/snowbird/state.py
@@ -36,6 +36,105 @@ def _get_warehouse_grants(
     return warehouse_grants
 
 
+def _get_database_grants(
+    grants_config: list[dict], cursor: SnowflakeCursor
+) -> dict:
+    managed_databases: set[str] = set()
+    for grant in grants_config:
+        for schema_path in grant.get("read_on_schemas", []) + grant.get(
+            "write_on_schemas", []
+        ):
+            managed_databases.add(schema_path.split(".")[0].lower())
+        for obj in grant.get("read_on_objects", []):
+            _, obj_path = obj.split(":", 1)
+            managed_databases.add(obj_path.split(".")[0].lower())
+
+    database_grants: dict = {}
+    for database in managed_databases:
+        try:
+            cursor.execute(f"show grants on database {database}")
+            database_grants[database] = cursor.fetchall()
+        except snowflake.connector.errors.ProgrammingError:
+            pass
+    return database_grants
+
+
+def _get_schema_grants(
+    grants_config: list[dict], cursor: SnowflakeCursor
+) -> dict:
+    managed_schemas: set[str] = set()
+    for grant in grants_config:
+        for schema_path in grant.get("read_on_schemas", []) + grant.get(
+            "write_on_schemas", []
+        ):
+            managed_schemas.add(schema_path.lower())
+        for obj in grant.get("read_on_objects", []):
+            _, obj_path = obj.split(":", 1)
+            parts = obj_path.split(".")
+            if len(parts) >= 3:
+                managed_schemas.add(f"{parts[0]}.{parts[1]}".lower())
+
+    schema_grants: dict = {}
+    for schema_path in managed_schemas:
+        try:
+            cursor.execute(f"show grants on schema {schema_path}")
+            schema_grants[schema_path] = cursor.fetchall()
+        except snowflake.connector.errors.ProgrammingError:
+            pass
+    return schema_grants
+
+
+def _get_future_schema_grants(
+    grants_config: list[dict], cursor: SnowflakeCursor
+) -> dict:
+    managed_schemas: set[str] = set()
+    for grant in grants_config:
+        for schema_path in grant.get("read_on_schemas", []):
+            managed_schemas.add(schema_path.lower())
+
+    future_grants: dict = {}
+    for schema_path in managed_schemas:
+        try:
+            cursor.execute(f"show future grants in schema {schema_path}")
+            future_grants[schema_path] = cursor.fetchall()
+        except snowflake.connector.errors.ProgrammingError:
+            pass
+    return future_grants
+
+
+_OBJECT_TYPE_MAP = {
+    "table": "table",
+    "view": "view",
+    "dynamic_table": "dynamic table",
+    "semantic_view": "semantic view",
+}
+
+
+def _get_object_grants(
+    grants_config: list[dict], cursor: SnowflakeCursor
+) -> dict:
+    managed_objects: list[tuple[str, str, str]] = []
+    for grant in grants_config:
+        for obj in grant.get("read_on_objects", []):
+            prefix, obj_path = obj.split(":", 1)
+            sf_type = _OBJECT_TYPE_MAP.get(prefix, prefix)
+            managed_objects.append((prefix, sf_type, obj_path.lower()))
+
+    object_grants: dict = {}
+    seen: set[str] = set()
+    for prefix, sf_type, obj_path in managed_objects:
+        key = f"{prefix}:{obj_path}"
+        if key in seen:
+            continue
+        seen.add(key)
+        try:
+            cursor.execute(f"show grants on {sf_type} {obj_path}")
+            object_grants[key] = cursor.fetchall()
+        except snowflake.connector.errors.ProgrammingError:
+            pass
+    return object_grants
+
+
 def _get_users_state(users: list[dict], cursor: SnowflakeCursor) -> list[dict]:
 
     state = []
@@ -105,6 +204,10 @@ def current_state(config: dict) -> dict:
         roles = cursor.execute("show roles").fetchall()
         grants_of_roles = _get_role_grants(roles_config, cursor)
         warehouse_grants = _get_warehouse_grants(grants_config, cursor)
+        database_grants = _get_database_grants(grants_config, cursor)
+        schema_grants = _get_schema_grants(grants_config, cursor)
+        future_schema_grants = _get_future_schema_grants(grants_config, cursor)
+        object_grants = _get_object_grants(grants_config, cursor)
         network_policies = _get_network_policies(network_policies_config, cursor)
     return {
         "databases": databases,
@@ -115,6 +218,10 @@ def current_state(config: dict) -> dict:
         "grants": {
             "of_roles": grants_of_roles,
             "on_warehouses": warehouse_grants,
+            "on_databases": database_grants,
+            "on_schemas": schema_grants,
+            "future_in_schemas": future_schema_grants,
+            "on_objects": object_grants,
         },
         "network_policies": network_policies,
     }

--- a/snowbird/state.py
+++ b/snowbird/state.py
@@ -18,6 +18,24 @@ def _get_role_grants(roles: list[dict], cursor: SnowflakeCursor) -> dict:
     return grants
 
 
+def _get_warehouse_grants(
+    grants_config: list[dict], cursor: SnowflakeCursor
+) -> dict:
+    managed_warehouses: set[str] = set()
+    for grant in grants_config:
+        for wh in grant.get("warehouses", []):
+            managed_warehouses.add(wh.lower())
+
+    warehouse_grants: dict = {}
+    for warehouse in managed_warehouses:
+        try:
+            cursor.execute(f"show grants on warehouse {warehouse}")
+            warehouse_grants[warehouse] = cursor.fetchall()
+        except snowflake.connector.errors.ProgrammingError:
+            pass
+    return warehouse_grants
+
+
 def _get_users_state(users: list[dict], cursor: SnowflakeCursor) -> list[dict]:
 
     state = []
@@ -77,6 +95,7 @@ def current_state(config: dict) -> dict:
     roles_config = config.get("roles", [])
     users_config = config.get("users", [])
     network_policies_config = config.get("network_policies", [])
+    grants_config = config.get("grants", [])
 
     with snowflake_cursor() as cursor:
         databases = cursor.execute("show databases").fetchall()
@@ -85,6 +104,7 @@ def current_state(config: dict) -> dict:
         users = _get_users_state(users_config, cursor)
         roles = cursor.execute("show roles").fetchall()
         grants_of_roles = _get_role_grants(roles_config, cursor)
+        warehouse_grants = _get_warehouse_grants(grants_config, cursor)
         network_policies = _get_network_policies(network_policies_config, cursor)
     return {
         "databases": databases,
@@ -92,6 +112,9 @@ def current_state(config: dict) -> dict:
         "schemas": schemas,
         "users": users,
         "roles": roles,
-        "grants": {"of_roles": grants_of_roles},
+        "grants": {
+            "of_roles": grants_of_roles,
+            "on_warehouses": warehouse_grants,
+        },
         "network_policies": network_policies,
     }

--- a/tests/test_execution_plan.py
+++ b/tests/test_execution_plan.py
@@ -1004,3 +1004,157 @@ def test_switching_executer_role():
     result = execution_plan(config)
     print(result)
     assert result == expected
+
+
+def test_grant_warehouse_skipped_when_already_exists():
+    config = {"grants": [{"role": "foo", "warehouses": ["bar"]}]}
+    state = {
+        "grants": {
+            "on_warehouses": {
+                "bar": [
+                    {"privilege": "USAGE", "grantee_name": "FOO"},
+                ]
+            }
+        },
+    }
+    expected = {
+        "use role useradmin",
+        'grant role foo to role "SYSADMIN"',
+    }
+    result = set(execution_plan(config=config, state=state))
+    print(result)
+    assert result == expected
+
+
+def test_grant_warehouse_when_not_in_state():
+    config = {"grants": [{"role": "foo", "warehouses": ["bar"]}]}
+    state = {
+        "grants": {
+            "on_warehouses": {
+                "bar": []
+            }
+        },
+    }
+    expected = {
+        "use role useradmin",
+        "grant usage on warehouse bar to role foo",
+        'grant role foo to role "SYSADMIN"',
+    }
+    result = set(execution_plan(config=config, state=state))
+    print(result)
+    assert result == expected
+
+
+def test_revoke_warehouse_from_unlisted_role():
+    config = {"grants": [{"role": "foo", "warehouses": ["bar"]}]}
+    state = {
+        "grants": {
+            "on_warehouses": {
+                "bar": [
+                    {"privilege": "USAGE", "grantee_name": "FOO"},
+                    {"privilege": "USAGE", "grantee_name": "ROGUE_ROLE"},
+                ]
+            }
+        },
+    }
+    expected = {
+        "use role useradmin",
+        'grant role foo to role "SYSADMIN"',
+        "revoke usage on warehouse bar from role rogue_role",
+    }
+    result = set(execution_plan(config=config, state=state))
+    print(result)
+    assert result == expected
+
+
+def test_revoke_warehouse_when_not_in_config():
+    config = {"grants": [{"role": "foo", "warehouses": ["bar"]}]}
+    state = {
+        "grants": {
+            "on_warehouses": {
+                "bar": [
+                    {"privilege": "USAGE", "grantee_name": "BAZ"},
+                ]
+            }
+        },
+    }
+    expected = {
+        "use role useradmin",
+        "grant usage on warehouse bar to role foo",
+        "revoke usage on warehouse bar from role baz",
+        'grant role foo to role "SYSADMIN"',
+    }
+    result = set(execution_plan(config=config, state=state))
+    print(result)
+    assert result == expected
+
+
+def test_grant_and_revoke_warehouse_mixed():
+    config = {
+        "grants": [
+            {"role": "foo", "warehouses": ["wh1", "wh2"]},
+        ]
+    }
+    state = {
+        "grants": {
+            "on_warehouses": {
+                "wh1": [
+                    {"privilege": "USAGE", "grantee_name": "FOO"},
+                    {"privilege": "USAGE", "grantee_name": "OLD_ROLE"},
+                ],
+                "wh2": [],
+            }
+        },
+    }
+    expected = {
+        "use role useradmin",
+        "grant usage on warehouse wh2 to role foo",
+        "revoke usage on warehouse wh1 from role old_role",
+        'grant role foo to role "SYSADMIN"',
+    }
+    result = set(execution_plan(config=config, state=state))
+    print(result)
+    assert result == expected
+
+
+def test_warehouse_grants_aggregated_across_entries():
+    config = {
+        "grants": [
+            {"role": "foo", "warehouses": ["wh1"]},
+            {"role": "bar", "warehouses": ["wh1"]},
+        ]
+    }
+    state = {
+        "grants": {
+            "on_warehouses": {
+                "wh1": [
+                    {"privilege": "USAGE", "grantee_name": "OLD_ROLE"},
+                ]
+            }
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert "grant usage on warehouse wh1 to role foo" in result
+    assert "grant usage on warehouse wh1 to role bar" in result
+    assert "revoke usage on warehouse wh1 from role old_role" in result
+
+
+def test_warehouse_ownership_not_revoked():
+    config = {"grants": [{"role": "foo", "warehouses": ["bar"]}]}
+    state = {
+        "grants": {
+            "on_warehouses": {
+                "bar": [
+                    {"privilege": "OWNERSHIP", "grantee_name": "SYSADMIN"},
+                    {"privilege": "USAGE", "grantee_name": "FOO"},
+                ]
+            }
+        },
+    }
+    expected = {
+        "use role useradmin",
+        'grant role foo to role "SYSADMIN"',
+    }
+    result = set(execution_plan(config=config, state=state))
+    print(result)
+    assert result == expected

--- a/tests/test_execution_plan.py
+++ b/tests/test_execution_plan.py
@@ -1409,13 +1409,21 @@ def test_future_read_revoked_from_unlisted_role():
     assert not any("revoke" in s and "foo" in s for s in result)
 
 
-def test_all_grants_always_reemitted_for_read_on_schemas():
-    """ALL grants are always re-emitted (idempotent), even when state exists."""
+def test_all_grants_skipped_when_future_grants_already_exist():
+    """ALL grants are skipped when all future grants already exist in state."""
     config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
     state = {
         "grants": {
-            "on_databases": {"db1": []},
-            "on_schemas": {"db1.sch1": []},
+            "on_databases": {
+                "db1": [
+                    {"privilege": "USAGE", "grantee_name": "FOO"},
+                ]
+            },
+            "on_schemas": {
+                "db1.sch1": [
+                    {"privilege": "USAGE", "grantee_name": "FOO"},
+                ]
+            },
             "future_in_schemas": {
                 "db1.sch1": [
                     {"privilege": "SELECT", "grant_on": "TABLE", "grantee_name": "FOO"},
@@ -1427,7 +1435,52 @@ def test_all_grants_always_reemitted_for_read_on_schemas():
         },
     }
     result = set(execution_plan(config=config, state=state))
-    # ALL grants should always be emitted
+    # ALL grants should NOT be emitted when future grants are already in place
+    assert "grant select on all tables in schema db1.sch1 to role foo" not in result
+    assert "grant select on all views in schema db1.sch1 to role foo" not in result
+    assert "grant select on all dynamic tables in schema db1.sch1 to role foo" not in result
+    assert "grant select on all semantic views in schema db1.sch1 to role foo" not in result
+
+
+def test_all_grants_skipped_with_underscored_grant_on():
+    """Snowflake returns DYNAMIC_TABLE/SEMANTIC_VIEW with underscores — must still match."""
+    config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
+    state = {
+        "grants": {
+            "on_databases": {
+                "db1": [{"privilege": "USAGE", "grantee_name": "FOO"}]
+            },
+            "on_schemas": {
+                "db1.sch1": [{"privilege": "USAGE", "grantee_name": "FOO"}]
+            },
+            "future_in_schemas": {
+                "db1.sch1": [
+                    {"privilege": "SELECT", "grant_on": "TABLE", "grantee_name": "FOO"},
+                    {"privilege": "SELECT", "grant_on": "VIEW", "grantee_name": "FOO"},
+                    {"privilege": "SELECT", "grant_on": "DYNAMIC_TABLE", "grantee_name": "FOO"},
+                    {"privilege": "SELECT", "grant_on": "SEMANTIC_VIEW", "grantee_name": "FOO"},
+                ]
+            },
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert "grant select on future dynamic tables in schema db1.sch1 to role foo" not in result
+    assert "grant select on future semantic views in schema db1.sch1 to role foo" not in result
+    assert "grant select on all dynamic tables in schema db1.sch1 to role foo" not in result
+    assert "grant select on all semantic views in schema db1.sch1 to role foo" not in result
+
+
+def test_all_grants_emitted_when_future_grants_missing():
+    """ALL grants are emitted when future grants are being newly added."""
+    config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
+    state = {
+        "grants": {
+            "on_databases": {"db1": []},
+            "on_schemas": {"db1.sch1": []},
+            "future_in_schemas": {"db1.sch1": []},
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
     assert "grant select on all tables in schema db1.sch1 to role foo" in result
     assert "grant select on all views in schema db1.sch1 to role foo" in result
     assert "grant select on all dynamic tables in schema db1.sch1 to role foo" in result

--- a/tests/test_execution_plan.py
+++ b/tests/test_execution_plan.py
@@ -1158,3 +1158,676 @@ def test_warehouse_ownership_not_revoked():
     result = set(execution_plan(config=config, state=state))
     print(result)
     assert result == expected
+
+
+# ===== Database USAGE stateful tests =====
+
+
+def test_database_usage_skipped_when_already_exists():
+    config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
+    state = {
+        "grants": {
+            "on_databases": {
+                "db1": [
+                    {"privilege": "USAGE", "grantee_name": "FOO"},
+                ]
+            },
+            "on_schemas": {
+                "db1.sch1": [
+                    {"privilege": "USAGE", "grantee_name": "FOO"},
+                ]
+            },
+            "future_in_schemas": {
+                "db1.sch1": [
+                    {"privilege": "SELECT", "grant_on": "TABLE", "grantee_name": "FOO"},
+                    {"privilege": "SELECT", "grant_on": "VIEW", "grantee_name": "FOO"},
+                    {"privilege": "SELECT", "grant_on": "DYNAMIC TABLE", "grantee_name": "FOO"},
+                    {"privilege": "SELECT", "grant_on": "SEMANTIC VIEW", "grantee_name": "FOO"},
+                ]
+            },
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert "grant usage on database db1 to role foo" not in result
+    assert "revoke usage on database db1 from role foo" not in result
+
+
+def test_database_usage_granted_when_missing():
+    config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
+    state = {
+        "grants": {
+            "on_databases": {"db1": []},
+            "on_schemas": {"db1.sch1": []},
+            "future_in_schemas": {"db1.sch1": []},
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert "grant usage on database db1 to role foo" in result
+
+
+def test_database_usage_revoked_from_unlisted_role():
+    config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
+    state = {
+        "grants": {
+            "on_databases": {
+                "db1": [
+                    {"privilege": "USAGE", "grantee_name": "FOO"},
+                    {"privilege": "USAGE", "grantee_name": "ROGUE"},
+                ]
+            },
+            "on_schemas": {"db1.sch1": []},
+            "future_in_schemas": {"db1.sch1": []},
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert "grant usage on database db1 to role foo" not in result
+    assert "revoke usage on database db1 from role rogue" in result
+
+
+def test_database_usage_aggregated_across_read_and_write():
+    config = {
+        "grants": [
+            {"role": "reader", "read_on_schemas": ["db1.sch1"]},
+            {"role": "writer", "write_on_schemas": ["db1.sch2"]},
+        ]
+    }
+    state = {
+        "grants": {
+            "on_databases": {
+                "db1": [
+                    {"privilege": "USAGE", "grantee_name": "OLD_ROLE"},
+                ]
+            },
+            "on_schemas": {"db1.sch1": [], "db1.sch2": []},
+            "future_in_schemas": {"db1.sch1": []},
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert "grant usage on database db1 to role reader" in result
+    assert "grant usage on database db1 to role writer" in result
+    assert "revoke usage on database db1 from role old_role" in result
+
+
+# ===== Schema USAGE stateful tests =====
+
+
+def test_schema_usage_skipped_when_already_exists():
+    config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
+    state = {
+        "grants": {
+            "on_databases": {"db1": []},
+            "on_schemas": {
+                "db1.sch1": [
+                    {"privilege": "USAGE", "grantee_name": "FOO"},
+                ]
+            },
+            "future_in_schemas": {"db1.sch1": []},
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert "grant usage on schema db1.sch1 to role foo" not in result
+
+
+def test_schema_usage_revoked_from_unlisted_role():
+    config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
+    state = {
+        "grants": {
+            "on_databases": {"db1": []},
+            "on_schemas": {
+                "db1.sch1": [
+                    {"privilege": "USAGE", "grantee_name": "FOO"},
+                    {"privilege": "USAGE", "grantee_name": "ROGUE"},
+                ]
+            },
+            "future_in_schemas": {"db1.sch1": []},
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert "revoke usage on schema db1.sch1 from role rogue" in result
+
+
+def test_schema_usage_aggregated_across_read_and_write():
+    config = {
+        "grants": [
+            {"role": "reader", "read_on_schemas": ["db1.sch1"]},
+            {"role": "writer", "write_on_schemas": ["db1.sch1"]},
+        ]
+    }
+    state = {
+        "grants": {
+            "on_databases": {"db1": []},
+            "on_schemas": {
+                "db1.sch1": [
+                    {"privilege": "USAGE", "grantee_name": "OLD_ROLE"},
+                ]
+            },
+            "future_in_schemas": {"db1.sch1": []},
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert "grant usage on schema db1.sch1 to role reader" in result
+    assert "grant usage on schema db1.sch1 to role writer" in result
+    assert "revoke usage on schema db1.sch1 from role old_role" in result
+
+
+def test_schema_usage_aggregated_from_read_on_objects():
+    config = {
+        "grants": [
+            {"role": "obj_reader", "read_on_objects": ["table:db1.sch1.t1"]},
+        ]
+    }
+    state = {
+        "grants": {
+            "on_databases": {"db1": []},
+            "on_schemas": {
+                "db1.sch1": [
+                    {"privilege": "USAGE", "grantee_name": "ROGUE"},
+                ]
+            },
+            "on_objects": {"table:db1.sch1.t1": []},
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert "grant usage on schema db1.sch1 to role obj_reader" in result
+    assert "revoke usage on schema db1.sch1 from role rogue" in result
+
+
+# ===== Future read grants stateful tests =====
+
+
+def test_future_read_skipped_when_already_exists():
+    config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
+    state = {
+        "grants": {
+            "on_databases": {"db1": []},
+            "on_schemas": {"db1.sch1": []},
+            "future_in_schemas": {
+                "db1.sch1": [
+                    {"privilege": "SELECT", "grant_on": "TABLE", "grantee_name": "FOO"},
+                    {"privilege": "SELECT", "grant_on": "VIEW", "grantee_name": "FOO"},
+                    {"privilege": "SELECT", "grant_on": "DYNAMIC TABLE", "grantee_name": "FOO"},
+                    {"privilege": "SELECT", "grant_on": "SEMANTIC VIEW", "grantee_name": "FOO"},
+                ]
+            },
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert "grant select on future tables in schema db1.sch1 to role foo" not in result
+    assert "grant select on future views in schema db1.sch1 to role foo" not in result
+    assert "grant select on future dynamic tables in schema db1.sch1 to role foo" not in result
+    assert "grant select on future semantic views in schema db1.sch1 to role foo" not in result
+
+
+def test_future_read_granted_when_missing():
+    config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
+    state = {
+        "grants": {
+            "on_databases": {"db1": []},
+            "on_schemas": {"db1.sch1": []},
+            "future_in_schemas": {"db1.sch1": []},
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert "grant select on future tables in schema db1.sch1 to role foo" in result
+    assert "grant select on future views in schema db1.sch1 to role foo" in result
+    assert "grant select on future dynamic tables in schema db1.sch1 to role foo" in result
+    assert "grant select on future semantic views in schema db1.sch1 to role foo" in result
+
+
+def test_future_read_revoked_from_unlisted_role():
+    config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
+    state = {
+        "grants": {
+            "on_databases": {"db1": []},
+            "on_schemas": {"db1.sch1": []},
+            "future_in_schemas": {
+                "db1.sch1": [
+                    {"privilege": "SELECT", "grant_on": "TABLE", "grantee_name": "FOO"},
+                    {"privilege": "SELECT", "grant_on": "TABLE", "grantee_name": "ROGUE"},
+                    {"privilege": "SELECT", "grant_on": "VIEW", "grantee_name": "FOO"},
+                    {"privilege": "SELECT", "grant_on": "VIEW", "grantee_name": "ROGUE"},
+                    {"privilege": "SELECT", "grant_on": "DYNAMIC TABLE", "grantee_name": "FOO"},
+                    {"privilege": "SELECT", "grant_on": "DYNAMIC TABLE", "grantee_name": "ROGUE"},
+                    {"privilege": "SELECT", "grant_on": "SEMANTIC VIEW", "grantee_name": "FOO"},
+                    {"privilege": "SELECT", "grant_on": "SEMANTIC VIEW", "grantee_name": "ROGUE"},
+                ]
+            },
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    # Should revoke future grants for rogue
+    assert "revoke select on future tables in schema db1.sch1 from role rogue" in result
+    assert "revoke select on future views in schema db1.sch1 from role rogue" in result
+    assert "revoke select on future dynamic tables in schema db1.sch1 from role rogue" in result
+    assert "revoke select on future semantic views in schema db1.sch1 from role rogue" in result
+    # Should also revoke ALL grants to clean up existing objects
+    assert "revoke select on all tables in schema db1.sch1 from role rogue" in result
+    assert "revoke select on all views in schema db1.sch1 from role rogue" in result
+    assert "revoke select on all dynamic tables in schema db1.sch1 from role rogue" in result
+    assert "revoke select on all semantic views in schema db1.sch1 from role rogue" in result
+    # Should NOT revoke foo
+    assert not any("revoke" in s and "foo" in s for s in result)
+
+
+def test_all_grants_always_reemitted_for_read_on_schemas():
+    """ALL grants are always re-emitted (idempotent), even when state exists."""
+    config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
+    state = {
+        "grants": {
+            "on_databases": {"db1": []},
+            "on_schemas": {"db1.sch1": []},
+            "future_in_schemas": {
+                "db1.sch1": [
+                    {"privilege": "SELECT", "grant_on": "TABLE", "grantee_name": "FOO"},
+                    {"privilege": "SELECT", "grant_on": "VIEW", "grantee_name": "FOO"},
+                    {"privilege": "SELECT", "grant_on": "DYNAMIC TABLE", "grantee_name": "FOO"},
+                    {"privilege": "SELECT", "grant_on": "SEMANTIC VIEW", "grantee_name": "FOO"},
+                ]
+            },
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    # ALL grants should always be emitted
+    assert "grant select on all tables in schema db1.sch1 to role foo" in result
+    assert "grant select on all views in schema db1.sch1 to role foo" in result
+    assert "grant select on all dynamic tables in schema db1.sch1 to role foo" in result
+    assert "grant select on all semantic views in schema db1.sch1 to role foo" in result
+
+
+# ===== CREATE grants stateful tests =====
+
+
+def test_create_grants_skipped_when_already_exists():
+    config = {"grants": [{"role": "foo", "write_on_schemas": ["db1.sch1"]}]}
+    state = {
+        "grants": {
+            "on_databases": {"db1": []},
+            "on_schemas": {
+                "db1.sch1": [
+                    {"privilege": "CREATE TABLE", "grantee_name": "FOO"},
+                    {"privilege": "CREATE VIEW", "grantee_name": "FOO"},
+                    {"privilege": "CREATE DYNAMIC TABLE", "grantee_name": "FOO"},
+                    {"privilege": "CREATE SEMANTIC VIEW", "grantee_name": "FOO"},
+                    {"privilege": "CREATE TASK", "grantee_name": "FOO"},
+                    {"privilege": "CREATE ALERT", "grantee_name": "FOO"},
+                    {"privilege": "CREATE MASKING POLICY", "grantee_name": "FOO"},
+                    {"privilege": "CREATE ROW ACCESS POLICY", "grantee_name": "FOO"},
+                    {"privilege": "CREATE PROCEDURE", "grantee_name": "FOO"},
+                ]
+            },
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert not any("grant create" in s for s in result)
+
+
+def test_create_grants_granted_when_missing():
+    config = {"grants": [{"role": "foo", "write_on_schemas": ["db1.sch1"]}]}
+    state = {
+        "grants": {
+            "on_databases": {"db1": []},
+            "on_schemas": {"db1.sch1": []},
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert "grant create table on schema db1.sch1 to role foo" in result
+    assert "grant create view on schema db1.sch1 to role foo" in result
+    assert "grant create dynamic table on schema db1.sch1 to role foo" in result
+    assert "grant create procedure on schema db1.sch1 to role foo" in result
+
+
+def test_create_grants_revoked_from_unlisted_role():
+    config = {"grants": [{"role": "foo", "write_on_schemas": ["db1.sch1"]}]}
+    state = {
+        "grants": {
+            "on_databases": {"db1": []},
+            "on_schemas": {
+                "db1.sch1": [
+                    {"privilege": "CREATE TABLE", "grantee_name": "FOO"},
+                    {"privilege": "CREATE TABLE", "grantee_name": "ROGUE"},
+                    {"privilege": "CREATE VIEW", "grantee_name": "FOO"},
+                    {"privilege": "CREATE VIEW", "grantee_name": "ROGUE"},
+                ]
+            },
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert "revoke create table on schema db1.sch1 from role rogue" in result
+    assert "revoke create view on schema db1.sch1 from role rogue" in result
+    assert not any("revoke create" in s and "foo" in s for s in result)
+
+
+def test_create_grants_partial_missing():
+    """Some CREATE types exist, some don't — only grants the missing ones."""
+    config = {"grants": [{"role": "foo", "write_on_schemas": ["db1.sch1"]}]}
+    state = {
+        "grants": {
+            "on_databases": {"db1": []},
+            "on_schemas": {
+                "db1.sch1": [
+                    {"privilege": "CREATE TABLE", "grantee_name": "FOO"},
+                ]
+            },
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert "grant create table on schema db1.sch1 to role foo" not in result
+    assert "grant create view on schema db1.sch1 to role foo" in result
+    assert "grant create procedure on schema db1.sch1 to role foo" in result
+
+
+# ===== Object SELECT stateful tests =====
+
+
+def test_object_select_skipped_when_already_exists():
+    config = {"grants": [{"role": "foo", "read_on_objects": ["table:db1.sch1.t1"]}]}
+    state = {
+        "grants": {
+            "on_databases": {"db1": []},
+            "on_schemas": {"db1.sch1": []},
+            "on_objects": {
+                "table:db1.sch1.t1": [
+                    {"privilege": "SELECT", "grantee_name": "FOO"},
+                ]
+            },
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert "grant select on table db1.sch1.t1 to role foo" not in result
+
+
+def test_object_select_granted_when_missing():
+    config = {"grants": [{"role": "foo", "read_on_objects": ["table:db1.sch1.t1"]}]}
+    state = {
+        "grants": {
+            "on_databases": {"db1": []},
+            "on_schemas": {"db1.sch1": []},
+            "on_objects": {"table:db1.sch1.t1": []},
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert "grant select on table db1.sch1.t1 to role foo" in result
+
+
+def test_object_select_revoked_from_unlisted_role():
+    config = {"grants": [{"role": "foo", "read_on_objects": ["table:db1.sch1.t1"]}]}
+    state = {
+        "grants": {
+            "on_databases": {"db1": []},
+            "on_schemas": {"db1.sch1": []},
+            "on_objects": {
+                "table:db1.sch1.t1": [
+                    {"privilege": "SELECT", "grantee_name": "FOO"},
+                    {"privilege": "SELECT", "grantee_name": "ROGUE"},
+                ]
+            },
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert "revoke select on table db1.sch1.t1 from role rogue" in result
+    assert not any("revoke" in s and "foo" in s for s in result)
+
+
+def test_object_select_not_revoked_when_covered_by_read_on_schemas():
+    """A role with read_on_schemas should not have its object SELECT revoked."""
+    config = {
+        "grants": [
+            {"role": "analyst", "read_on_schemas": ["db1.sch1"]},
+            {"role": "special", "read_on_objects": ["table:db1.sch1.t1"]},
+        ]
+    }
+    state = {
+        "grants": {
+            "on_databases": {"db1": []},
+            "on_schemas": {"db1.sch1": []},
+            "future_in_schemas": {"db1.sch1": []},
+            "on_objects": {
+                "table:db1.sch1.t1": [
+                    {"privilege": "SELECT", "grantee_name": "ANALYST"},
+                    {"privilege": "SELECT", "grantee_name": "SPECIAL"},
+                ]
+            },
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert not any("revoke" in s and "analyst" in s and "db1.sch1.t1" in s for s in result)
+    assert not any("revoke" in s and "special" in s and "db1.sch1.t1" in s for s in result)
+
+
+def test_object_select_revoked_when_not_covered_by_schema_or_object():
+    """A role not in read_on_schemas or read_on_objects should be revoked."""
+    config = {
+        "grants": [
+            {"role": "analyst", "read_on_schemas": ["db1.sch1"]},
+            {"role": "special", "read_on_objects": ["table:db1.sch1.t1"]},
+        ]
+    }
+    state = {
+        "grants": {
+            "on_databases": {"db1": []},
+            "on_schemas": {"db1.sch1": []},
+            "future_in_schemas": {"db1.sch1": []},
+            "on_objects": {
+                "table:db1.sch1.t1": [
+                    {"privilege": "SELECT", "grantee_name": "ANALYST"},
+                    {"privilege": "SELECT", "grantee_name": "SPECIAL"},
+                    {"privilege": "SELECT", "grantee_name": "ROGUE"},
+                ]
+            },
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert "revoke select on table db1.sch1.t1 from role rogue" in result
+
+
+# ===== Stateless mode compatibility =====
+
+
+def test_stateless_mode_grants_unconditionally():
+    """When no state is provided, all grants are emitted unconditionally."""
+    config = {
+        "grants": [
+            {
+                "role": "foo",
+                "read_on_schemas": ["db1.sch1"],
+                "write_on_schemas": ["db1.sch2"],
+                "read_on_objects": ["table:db1.sch1.t1"],
+                "warehouses": ["wh1"],
+            }
+        ]
+    }
+    result = set(execution_plan(config=config))
+    assert "grant usage on database db1 to role foo" in result
+    assert "grant usage on schema db1.sch1 to role foo" in result
+    assert "grant usage on schema db1.sch2 to role foo" in result
+    assert "grant usage on warehouse wh1 to role foo" in result
+    assert "grant select on future tables in schema db1.sch1 to role foo" in result
+    assert "grant create table on schema db1.sch2 to role foo" in result
+    assert "grant select on table db1.sch1.t1 to role foo" in result
+    assert not any("revoke" in s for s in result)
+
+
+# ===== Ownership transfer tests =====
+
+
+def test_database_ownership_transferred_when_wrong_owner():
+    config = {
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+    }
+    state = {
+        "databases": [
+            {
+                "name": "db1",
+                "retention_time": "7",
+                "options": "",
+                "owner": "ACCOUNTADMIN",
+            }
+        ],
+        "schemas": [
+            {
+                "name": "sch1",
+                "database_name": "db1",
+                "retention_time": "7",
+                "options": "",
+                "owner": "SYSADMIN",
+            }
+        ],
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert "grant ownership on database db1 to role sysadmin copy current grants" in result
+
+
+def test_database_ownership_not_checked_when_new():
+    """New objects have no state, so ownership should not be checked."""
+    config = {
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+    }
+    result = set(execution_plan(config=config))
+    assert not any("ownership" in s for s in result)
+
+
+def test_schema_ownership_transferred_when_wrong_owner():
+    config = {
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+    }
+    state = {
+        "databases": [
+            {
+                "name": "db1",
+                "retention_time": "7",
+                "options": "",
+                "owner": "SYSADMIN",
+            }
+        ],
+        "schemas": [
+            {
+                "name": "sch1",
+                "database_name": "db1",
+                "retention_time": "7",
+                "options": "",
+                "owner": "ACCOUNTADMIN",
+            }
+        ],
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert (
+        "grant ownership on schema db1.sch1 to role sysadmin copy current grants"
+        in result
+    )
+
+
+def test_warehouse_ownership_transferred_when_wrong_owner():
+    config = {"warehouses": [{"name": "wh1", "size": "xsmall"}]}
+    state = {
+        "warehouses": [{"name": "wh1", "size": "XSMALL", "owner": "ACCOUNTADMIN"}],
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert (
+        "grant ownership on warehouse wh1 to role sysadmin copy current grants"
+        in result
+    )
+
+
+def test_role_ownership_transferred_when_wrong_owner():
+    config = {"roles": [{"name": "myrole"}]}
+    state = {
+        "roles": [{"name": "myrole", "owner": "ACCOUNTADMIN"}],
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert (
+        "grant ownership on role myrole to role useradmin copy current grants" in result
+    )
+
+
+def test_role_ownership_not_transferred_when_correct():
+    config = {"roles": [{"name": "myrole"}]}
+    state = {
+        "roles": [{"name": "myrole", "owner": "USERADMIN"}],
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert not any("ownership" in s for s in result)
+
+
+# ===== Revoke unmanaged privileges tests =====
+
+
+def test_unmanaged_privilege_revoked_on_database():
+    config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
+    state = {
+        "grants": {
+            "on_databases": {
+                "db1": [
+                    {"privilege": "USAGE", "grantee_name": "FOO"},
+                    {"privilege": "MODIFY", "grantee_name": "BAR"},
+                    {"privilege": "MONITOR", "grantee_name": "BAZ"},
+                    {"privilege": "OWNERSHIP", "grantee_name": "SYSADMIN"},
+                ]
+            },
+            "on_schemas": {},
+            "future_in_schemas": {},
+            "on_objects": {},
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert "revoke modify on database db1 from role bar" in result
+    assert "revoke monitor on database db1 from role baz" in result
+    assert not any("revoke ownership" in s for s in result)
+    assert "revoke usage on database db1 from role foo" not in result
+
+
+def test_unmanaged_privilege_revoked_on_warehouse():
+    config = {"grants": [{"role": "foo", "warehouses": ["wh1"]}]}
+    state = {
+        "grants": {
+            "on_warehouses": {
+                "wh1": [
+                    {"privilege": "USAGE", "grantee_name": "FOO"},
+                    {"privilege": "OPERATE", "grantee_name": "FOO"},
+                    {"privilege": "MODIFY", "grantee_name": "BAR"},
+                    {"privilege": "OWNERSHIP", "grantee_name": "SYSADMIN"},
+                ]
+            },
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert "revoke operate on warehouse wh1 from role foo" in result
+    assert "revoke modify on warehouse wh1 from role bar" in result
+    assert not any("revoke ownership" in s for s in result)
+    assert "revoke usage on warehouse wh1 from role foo" not in result
+
+
+def test_unmanaged_privilege_revoked_on_schema():
+    config = {
+        "grants": [
+            {"role": "foo", "read_on_schemas": ["db1.sch1"]},
+            {"role": "bar", "write_on_schemas": ["db1.sch1"]},
+        ]
+    }
+    state = {
+        "grants": {
+            "on_databases": {},
+            "on_schemas": {
+                "db1.sch1": [
+                    {"privilege": "USAGE", "grantee_name": "FOO"},
+                    {"privilege": "USAGE", "grantee_name": "BAR"},
+                    {"privilege": "CREATE TABLE", "grantee_name": "BAR"},
+                    {"privilege": "MODIFY", "grantee_name": "BAZ"},
+                    {"privilege": "OWNERSHIP", "grantee_name": "SYSADMIN"},
+                ]
+            },
+            "future_in_schemas": {},
+            "on_objects": {},
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert "revoke modify on schema db1.sch1 from role baz" in result
+    assert not any("revoke ownership" in s for s in result)
+    assert "revoke usage on schema db1.sch1 from role foo" not in result
+    assert "revoke create table on schema db1.sch1 from role bar" not in result
+
+
+def test_unmanaged_privilege_not_revoked_without_state():
+    """When no state is available, nothing should be revoked."""
+    config = {"grants": [{"role": "foo", "warehouses": ["wh1"]}]}
+    result = set(execution_plan(config=config))
+    assert not any("revoke" in s for s in result)


### PR DESCRIPTION
## Summary

Grants are now **stateful** — Snowbird diffs the desired config against current Snowflake state and only emits the SQL needed to converge. Previously, all grant statements were emitted unconditionally on every run.

This is a **breaking change**: grants not declared in `snowflake.yml` will now be **revoked**. Use `--stateless` to opt out.

## Changes

### Stateful grant/revoke diffing (`plan.py`)
- **Warehouse USAGE** — grant missing, revoke undeclared
- **Database USAGE** — grant missing, revoke undeclared
- **Schema USAGE** — grant missing, revoke undeclared
- **Future read grants** (`read_on_schemas`) — grant missing, revoke undeclared per object type (tables, views, dynamic tables, semantic views)
- **ALL grants** (`grant select on all ...`) — only emitted during bootstrap (when future grants are being newly added), not on every run
- **CREATE grants** (`write_on_schemas`) — grant missing, revoke undeclared per create type
- **Object SELECT** (`read_on_objects`) — grant missing, revoke undeclared; roles covered by `read_on_schemas` are not revoked
- **Unmanaged privileges** — MODIFY, OPERATE, MONITOR etc. on managed resources are revoked; OWNERSHIP is never revoked
- Fix `grant_on` comparison for `DYNAMIC_TABLE`/`SEMANTIC_VIEW` (Snowflake returns underscores, code expected spaces)

### Ownership verification (`plan.py`)
- Databases, schemas, warehouses auto-transferred to `sysadmin` if owned by another role
- Roles auto-transferred to `useradmin` if owned by another role

### State fetching (`state.py`)
- New state collectors: `_get_warehouse_grants`, `_get_database_grants`, `_get_schema_grants`, `_get_future_schema_grants`, `_get_object_grants`
- `current_state()` now returns `on_warehouses`, `on_databases`, `on_schemas`, `future_in_schemas`, `on_objects` under `grants`

### CLI output (`main.py`)
- Plan overview now shows grant **and** revoke counts (previously hardcoded `0 revoke`)
- Added warehouse, database, schema rows to the overview table

### Version
Bumped to `0.6.0`