### PR TITLE
fix: grant categorization and user-level revoke handling

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -64,6 +64,8 @@ Each phase begins with an explicit `USE ROLE` statement.
 
 ## Communication Style
 
+**Ask questions early and often.** The barrier to ask clarifying questions should be low. When something is unclear, ambiguous, or can be solved in multiple reasonable ways — ask before assuming.
+
 Always use caveman skills when applicable:
 
 - **caveman** — All responses in caveman mode (full intensity by default)

--- a/snowbird/main.py
+++ b/snowbird/main.py
@@ -90,6 +90,7 @@ def plan(config, silent, state, stateless, print_execution_plan):
     revoke_selects = plan_overview.get("revoke_selects", [])
     revoke_select_on_objects = plan_overview.get("revoke_select_on_objects", [])
     revoke_create = plan_overview.get("revoke_create", [])
+    revoke_other = plan_overview.get("revoke_other", [])
 
     if silent == False:
         click.echo("\nCreate or modify:")
@@ -170,6 +171,7 @@ def plan(config, silent, state, stateless, print_execution_plan):
                     revoke_selects,
                     revoke_select_on_objects,
                     revoke_create,
+                    revoke_other,
                 ],
             )
         )
@@ -209,6 +211,11 @@ def plan(config, silent, state, stateless, print_execution_plan):
             "Role to user:".ljust(20)
             + f"{str(len(grant_users)).rjust(2)} grant, {str(len(revoke_users)).rjust(3)} revoke"
         )
+        if revoke_other:
+            click.echo(
+                "Other:".ljust(20)
+                + f"{''.rjust(2)}        {str(len(revoke_other)).rjust(3)} revoke"
+            )
         click.echo("")
     if print_execution_plan == True:
         if not silent:

--- a/snowbird/plan.py
+++ b/snowbird/plan.py
@@ -1098,6 +1098,19 @@ def overview(execution_plan: dict) -> dict:
     revoke_users = [
         s for s in execution_plan if "revoke role" in s and "from user" in s
     ]
+    categorized_revokes = set(
+        revoke_warehouses
+        + revoke_databases
+        + revoke_schemas
+        + revoke_selects
+        + revoke_select_on_objects
+        + revoke_create
+        + revoke_roles
+        + revoke_users
+    )
+    revoke_other = [
+        s for s in execution_plan if "revoke " in s and s not in categorized_revokes
+    ]
     return {
         "create_databases": create_databases,
         "modify_databases": modify_databases,
@@ -1127,4 +1140,5 @@ def overview(execution_plan: dict) -> dict:
         "revoke_create": revoke_create,
         "revoke_roles": revoke_roles,
         "revoke_users": revoke_users,
+        "revoke_other": revoke_other,
     }

--- a/snowbird/plan.py
+++ b/snowbird/plan.py
@@ -377,6 +377,20 @@ def _create_roles_execution_plan(roles: list[dict], state: dict) -> list[str]:
     return execution_plan
 
 
+def _actual_grants(grant_state: list[dict]) -> set[tuple[str, str, str]]:
+    """Build set of (privilege, grantee_type, grantee_name) from state, excluding OWNERSHIP."""
+    return {
+        (
+            g["privilege"].lower(),
+            g.get("granted_to", "ROLE").lower(),
+            g["grantee_name"].lower(),
+        )
+        for g in grant_state
+        if g["privilege"].lower() != "ownership"
+        and g.get("granted_to", "ROLE").lower() in ("role", "user")
+    }
+
+
 def _grant_role_execution_plan(grants: list[dict], state: dict) -> list[str]:
     if len(grants) == 0:
         return []
@@ -437,125 +451,61 @@ def _grant_role_execution_plan(grants: list[dict], state: dict) -> list[str]:
     on_warehouses_state = state.get("on_warehouses", {})
     for warehouse, desired_roles in desired_warehouse_roles.items():
         warehouse_grant_state = on_warehouses_state.get(warehouse)
+        desired = {("usage", "role", r) for r in desired_roles}
         if warehouse_grant_state is None:
-            for role in desired_roles:
-                stmt = jinja_env.from_string(grant_role_usage_on_warehouse).render(
-                    role=role, warehouse=warehouse
+            for priv, gtype, name in desired:
+                execution_plan.add(
+                    jinja_env.from_string(grant_role_usage_on_warehouse).render(
+                        role=name, warehouse=warehouse
+                    )
                 )
-                execution_plan.add(stmt)
         else:
-            actual_role_grantees = {
-                g["grantee_name"].lower()
-                for g in warehouse_grant_state
-                if g["privilege"].lower() == "usage"
-                and g.get("granted_to", "ROLE").lower() == "role"
-            }
-            actual_user_grantees = {
-                g["grantee_name"].lower()
-                for g in warehouse_grant_state
-                if g["privilege"].lower() == "usage"
-                and g.get("granted_to", "ROLE").lower() == "user"
-            }
-            for role in desired_roles - actual_role_grantees:
-                stmt = jinja_env.from_string(grant_role_usage_on_warehouse).render(
-                    role=role, warehouse=warehouse
+            actual = _actual_grants(warehouse_grant_state)
+            for priv, gtype, name in desired - actual:
+                execution_plan.add(
+                    jinja_env.from_string(grant_role_usage_on_warehouse).render(
+                        role=name, warehouse=warehouse
+                    )
                 )
-                execution_plan.add(stmt)
-            for grantee in actual_role_grantees - desired_roles:
+            for priv, gtype, name in actual - desired:
                 execution_plan.add(
                     jinja_env.from_string(revoke_privilege).render(
-                        privilege_clause=f"usage on warehouse {warehouse}",
-                        grantee_type="role",
-                        grantee_name=grantee,
+                        privilege_clause=f"{priv} on warehouse {warehouse}",
+                        grantee_type=gtype,
+                        grantee_name=name,
                     )
                 )
-            for grantee in actual_user_grantees:
-                execution_plan.add(
-                    jinja_env.from_string(revoke_privilege).render(
-                        privilege_clause=f"usage on warehouse {warehouse}",
-                        grantee_type="user",
-                        grantee_name=grantee,
-                    )
-                )
-            # Revoke unmanaged privileges (anything that isn't USAGE or OWNERSHIP)
-            for g in warehouse_grant_state:
-                priv = g["privilege"].lower()
-                grantee_type = g.get("granted_to", "ROLE").lower()
-                if priv not in ("usage", "ownership") and grantee_type in (
-                    "role",
-                    "user",
-                ):
-                    execution_plan.add(
-                        jinja_env.from_string(revoke_privilege).render(
-                            privilege_clause=f"{priv} on warehouse {warehouse}",
-                            grantee_type=grantee_type,
-                            grantee_name=g["grantee_name"].lower(),
-                        )
-                    )
 
     # --- Database USAGE ---
     on_databases_state = state.get("on_databases", {})
     for database, desired_roles in desired_database_roles.items():
         db_grant_state = on_databases_state.get(database)
+        desired = {("usage", "role", r) for r in desired_roles}
         if db_grant_state is None:
-            for role in desired_roles:
+            for priv, gtype, name in desired:
                 execution_plan.add(
                     jinja_env.from_string(grant_role_usage_on_database).render(
-                        role=role, database=database
+                        role=name, database=database
                     )
                 )
         else:
-            actual_role_grantees = {
-                g["grantee_name"].lower()
-                for g in db_grant_state
-                if g["privilege"].lower() == "usage"
-                and g.get("granted_to", "ROLE").lower() == "role"
-            }
-            actual_user_grantees = {
-                g["grantee_name"].lower()
-                for g in db_grant_state
-                if g["privilege"].lower() == "usage"
-                and g.get("granted_to", "ROLE").lower() == "user"
-            }
-            for role in desired_roles - actual_role_grantees:
+            actual = _actual_grants(db_grant_state)
+            for priv, gtype, name in desired - actual:
                 execution_plan.add(
                     jinja_env.from_string(grant_role_usage_on_database).render(
-                        role=role, database=database
+                        role=name, database=database
                     )
                 )
-            for grantee in actual_role_grantees - desired_roles:
+            for priv, gtype, name in actual - desired:
                 execution_plan.add(
                     jinja_env.from_string(revoke_privilege).render(
-                        privilege_clause=f"usage on database {database}",
-                        grantee_type="role",
-                        grantee_name=grantee,
+                        privilege_clause=f"{priv} on database {database}",
+                        grantee_type=gtype,
+                        grantee_name=name,
                     )
                 )
-            for grantee in actual_user_grantees:
-                execution_plan.add(
-                    jinja_env.from_string(revoke_privilege).render(
-                        privilege_clause=f"usage on database {database}",
-                        grantee_type="user",
-                        grantee_name=grantee,
-                    )
-                )
-            # Revoke unmanaged privileges
-            for g in db_grant_state:
-                priv = g["privilege"].lower()
-                grantee_type = g.get("granted_to", "ROLE").lower()
-                if priv not in ("usage", "ownership") and grantee_type in (
-                    "role",
-                    "user",
-                ):
-                    execution_plan.add(
-                        jinja_env.from_string(revoke_privilege).render(
-                            privilege_clause=f"{priv} on database {database}",
-                            grantee_type=grantee_type,
-                            grantee_name=g["grantee_name"].lower(),
-                        )
-                    )
 
-    # --- Schema USAGE ---
+    # --- Schema grants (USAGE + CREATE) ---
     on_schemas_state = state.get("on_schemas", {})
     create_types = [
         "table",
@@ -568,186 +518,135 @@ def _grant_role_execution_plan(grants: list[dict], state: dict) -> list[str]:
         "row access policy",
         "procedure",
     ]
-    for schema_path, desired_roles in desired_schema_roles.items():
+    all_managed_schemas = set(desired_schema_roles.keys()) | set(desired_create.keys())
+    for schema_path in all_managed_schemas:
         database, schema = schema_path.split(".")
         schema_grant_state = on_schemas_state.get(schema_path)
-        if schema_grant_state is None:
-            for role in desired_roles:
-                execution_plan.add(
-                    jinja_env.from_string(grant_role_usage_on_schema).render(
-                        role=role, database=database, schema=schema
-                    )
-                )
-        else:
-            actual_role_grantees = {
-                g["grantee_name"].lower()
-                for g in schema_grant_state
-                if g["privilege"].lower() == "usage"
-                and g.get("granted_to", "ROLE").lower() == "role"
-            }
-            actual_user_grantees = {
-                g["grantee_name"].lower()
-                for g in schema_grant_state
-                if g["privilege"].lower() == "usage"
-                and g.get("granted_to", "ROLE").lower() == "user"
-            }
-            for role in desired_roles - actual_role_grantees:
-                execution_plan.add(
-                    jinja_env.from_string(grant_role_usage_on_schema).render(
-                        role=role, database=database, schema=schema
-                    )
-                )
-            for grantee in actual_role_grantees - desired_roles:
-                execution_plan.add(
-                    jinja_env.from_string(revoke_privilege).render(
-                        privilege_clause=f"usage on schema {database}.{schema}",
-                        grantee_type="role",
-                        grantee_name=grantee,
-                    )
-                )
-            for grantee in actual_user_grantees:
-                execution_plan.add(
-                    jinja_env.from_string(revoke_privilege).render(
-                        privilege_clause=f"usage on schema {database}.{schema}",
-                        grantee_type="user",
-                        grantee_name=grantee,
-                    )
-                )
-            # Revoke unmanaged privileges (not USAGE, not CREATE types, not OWNERSHIP)
-            managed_schema_privs = {"usage", "ownership"}
+
+        desired = set()
+        for role in desired_schema_roles.get(schema_path, set()):
+            desired.add(("usage", "role", role))
+        for role in desired_create.get(schema_path, set()):
             for ct in create_types:
-                managed_schema_privs.add(f"create {ct}")
-            for g in schema_grant_state:
-                priv = g["privilege"].lower()
-                grantee_type = g.get("granted_to", "ROLE").lower()
-                if priv not in managed_schema_privs and grantee_type in (
-                    "role",
-                    "user",
-                ):
+                desired.add((f"create {ct}", "role", role))
+
+        if schema_grant_state is None:
+            for priv, gtype, name in desired:
+                if priv == "usage":
                     execution_plan.add(
-                        jinja_env.from_string(revoke_privilege).render(
-                            privilege_clause=f"{priv} on schema {schema_path}",
-                            grantee_type=grantee_type,
-                            grantee_name=g["grantee_name"].lower(),
+                        jinja_env.from_string(grant_role_usage_on_schema).render(
+                            role=name, database=database, schema=schema
                         )
                     )
+                elif priv.startswith("create "):
+                    execution_plan.add(
+                        jinja_env.from_string(grant_role_create_on_schema).render(
+                            type=priv[7:],
+                            role=name,
+                            database=database,
+                            schema=schema,
+                        )
+                    )
+        else:
+            actual = _actual_grants(schema_grant_state)
+            for priv, gtype, name in desired - actual:
+                if priv == "usage":
+                    execution_plan.add(
+                        jinja_env.from_string(grant_role_usage_on_schema).render(
+                            role=name, database=database, schema=schema
+                        )
+                    )
+                elif priv.startswith("create "):
+                    execution_plan.add(
+                        jinja_env.from_string(grant_role_create_on_schema).render(
+                            type=priv[7:],
+                            role=name,
+                            database=database,
+                            schema=schema,
+                        )
+                    )
+            for priv, gtype, name in actual - desired:
+                execution_plan.add(
+                    jinja_env.from_string(revoke_privilege).render(
+                        privilege_clause=f"{priv} on schema {schema_path}",
+                        grantee_type=gtype,
+                        grantee_name=name,
+                    )
+                )
 
     # --- Future read grants (read_on_schemas) ---
     future_in_schemas_state = state.get("future_in_schemas", {})
-    future_grant_types = [
-        ("table", grant_role_future_read_on_tables_in_schema, "tables"),
-        ("view", grant_role_future_read_on_views_in_schema, "views"),
-        (
-            "dynamic table",
+    future_grant_map = {
+        "table": (grant_role_future_read_on_tables_in_schema, "tables"),
+        "view": (grant_role_future_read_on_views_in_schema, "views"),
+        "dynamic table": (
             grant_role_future_read_on_dynamic_tables_in_schema,
             "dynamic tables",
         ),
-        (
-            "semantic view",
+        "semantic view": (
             grant_role_future_read_on_semantic_views_in_schema,
             "semantic views",
         ),
-    ]
+    }
     # Track (schema_path, role) pairs that need new future grants — these also
     # need ALL grants to bootstrap existing objects in that schema.
     schemas_needing_bootstrap: set[tuple[str, str]] = set()
     for schema_path, desired_roles in desired_future_read.items():
         database, schema = schema_path.split(".")
         future_schema_state = future_in_schemas_state.get(schema_path)
-        for grant_on_type, grant_tmpl, type_plural in future_grant_types:
-            if future_schema_state is None:
-                for role in desired_roles:
-                    schemas_needing_bootstrap.add((schema_path, role))
-                    execution_plan.add(
-                        jinja_env.from_string(grant_tmpl).render(
-                            role=role, database=database, schema=schema
-                        )
-                    )
-            else:
-                actual_role_grantees = {
-                    g["grantee_name"].lower()
-                    for g in future_schema_state
-                    if g["privilege"].lower() == "select"
-                    and g["grant_on"].lower().replace("_", " ") == grant_on_type
-                }
-                for role in desired_roles - actual_role_grantees:
-                    schemas_needing_bootstrap.add((schema_path, role))
-                    execution_plan.add(
-                        jinja_env.from_string(grant_tmpl).render(
-                            role=role, database=database, schema=schema
-                        )
-                    )
-                for grantee in actual_role_grantees - desired_roles:
-                    execution_plan.add(
-                        jinja_env.from_string(revoke_privilege).render(
-                            privilege_clause=f"select on future {type_plural} in schema {database}.{schema}",
-                            grantee_type="role",
-                            grantee_name=grantee,
-                        )
-                    )
-                    # Also revoke on existing objects to clean up
-                    execution_plan.add(
-                        jinja_env.from_string(revoke_privilege).render(
-                            privilege_clause=f"select on all {type_plural} in schema {database}.{schema}",
-                            grantee_type="role",
-                            grantee_name=grantee,
-                        )
-                    )
 
-    # --- CREATE grants (write_on_schemas) ---
-    for schema_path, desired_roles in desired_create.items():
-        database, schema = schema_path.split(".")
-        schema_grant_state = on_schemas_state.get(schema_path)
-        for create_type in create_types:
-            privilege_name = f"create {create_type}"
-            if schema_grant_state is None:
-                for role in desired_roles:
-                    execution_plan.add(
-                        jinja_env.from_string(grant_role_create_on_schema).render(
-                            type=create_type,
-                            role=role,
-                            database=database,
-                            schema=schema,
-                        )
+        desired = {
+            ("select", grant_on_type, role)
+            for grant_on_type in future_grant_map
+            for role in desired_roles
+        }
+
+        if future_schema_state is None:
+            for priv, grant_on_type, role in desired:
+                schemas_needing_bootstrap.add((schema_path, role))
+                grant_tmpl = future_grant_map[grant_on_type][0]
+                execution_plan.add(
+                    jinja_env.from_string(grant_tmpl).render(
+                        role=role, database=database, schema=schema
                     )
-            else:
-                actual_role_grantees = {
-                    g["grantee_name"].lower()
-                    for g in schema_grant_state
-                    if g["privilege"].lower() == privilege_name
-                    and g.get("granted_to", "ROLE").lower() == "role"
-                }
-                actual_user_grantees = {
-                    g["grantee_name"].lower()
-                    for g in schema_grant_state
-                    if g["privilege"].lower() == privilege_name
-                    and g.get("granted_to", "").lower() == "user"
-                }
-                for role in desired_roles - actual_role_grantees:
-                    execution_plan.add(
-                        jinja_env.from_string(grant_role_create_on_schema).render(
-                            type=create_type,
-                            role=role,
-                            database=database,
-                            schema=schema,
-                        )
+                )
+        else:
+            actual = {
+                (
+                    g["privilege"].lower(),
+                    g["grant_on"].lower().replace("_", " "),
+                    g["grantee_name"].lower(),
+                )
+                for g in future_schema_state
+                if g["privilege"].lower() != "ownership"
+            }
+            for priv, grant_on_type, role in desired - actual:
+                schemas_needing_bootstrap.add((schema_path, role))
+                grant_tmpl = future_grant_map[grant_on_type][0]
+                execution_plan.add(
+                    jinja_env.from_string(grant_tmpl).render(
+                        role=role, database=database, schema=schema
                     )
-                for grantee in actual_role_grantees - desired_roles:
-                    execution_plan.add(
-                        jinja_env.from_string(revoke_privilege).render(
-                            privilege_clause=f"create {create_type} on schema {database}.{schema}",
-                            grantee_type="role",
-                            grantee_name=grantee,
-                        )
+                )
+            for priv, grant_on_type, grantee in actual - desired:
+                type_plural = future_grant_map.get(
+                    grant_on_type, (None, f"{grant_on_type}s")
+                )[1]
+                execution_plan.add(
+                    jinja_env.from_string(revoke_privilege).render(
+                        privilege_clause=f"{priv} on future {type_plural} in schema {database}.{schema}",
+                        grantee_type="role",
+                        grantee_name=grantee,
                     )
-                for grantee in actual_user_grantees:
-                    execution_plan.add(
-                        jinja_env.from_string(revoke_privilege).render(
-                            privilege_clause=f"create {create_type} on schema {database}.{schema}",
-                            grantee_type="user",
-                            grantee_name=grantee,
-                        )
+                )
+                # Also revoke on existing objects to clean up
+                execution_plan.add(
+                    jinja_env.from_string(revoke_privilege).render(
+                        privilege_clause=f"{priv} on all {type_plural} in schema {database}.{schema}",
+                        grantee_type="role",
+                        grantee_name=grantee,
                     )
+                )
 
     # --- Object SELECT grants (read_on_objects) ---
     on_objects_state = state.get("on_objects", {})
@@ -760,12 +659,16 @@ def _grant_role_execution_plan(grants: list[dict], state: dict) -> list[str]:
         expanded_desired = explicitly_desired | desired_future_read.get(
             containing_schema, set()
         )
+        obj_fqn = f"{info['sf_type']} {info['db']}.{info['schema']}.{info['name']}"
+
+        desired_to_grant = {("select", "role", r) for r in explicitly_desired}
+        desired_to_keep = {("select", "role", r) for r in expanded_desired}
 
         if obj_state is None:
-            for role in explicitly_desired:
+            for priv, gtype, name in desired_to_grant:
                 execution_plan.add(
                     jinja_env.from_string(grant_role_select_on_object).render(
-                        role=role,
+                        role=name,
                         object_type=info["sf_type"],
                         database=info["db"],
                         schema=info["schema"],
@@ -773,42 +676,23 @@ def _grant_role_execution_plan(grants: list[dict], state: dict) -> list[str]:
                     )
                 )
         else:
-            actual_role_grantees = {
-                g["grantee_name"].lower()
-                for g in obj_state
-                if g["privilege"].lower() == "select"
-                and g.get("granted_to", "ROLE").lower() == "role"
-            }
-            actual_user_grantees = {
-                g["grantee_name"].lower()
-                for g in obj_state
-                if g["privilege"].lower() == "select"
-                and g.get("granted_to", "").lower() == "user"
-            }
-            for role in explicitly_desired - actual_role_grantees:
+            actual = _actual_grants(obj_state)
+            for priv, gtype, name in desired_to_grant - actual:
                 execution_plan.add(
                     jinja_env.from_string(grant_role_select_on_object).render(
-                        role=role,
+                        role=name,
                         object_type=info["sf_type"],
                         database=info["db"],
                         schema=info["schema"],
                         object_name=info["name"],
                     )
                 )
-            for grantee in actual_role_grantees - expanded_desired:
+            for priv, gtype, name in actual - desired_to_keep:
                 execution_plan.add(
                     jinja_env.from_string(revoke_privilege).render(
-                        privilege_clause=f"select on {info['sf_type']} {info['db']}.{info['schema']}.{info['name']}",
-                        grantee_type="role",
-                        grantee_name=grantee,
-                    )
-                )
-            for grantee in actual_user_grantees:
-                execution_plan.add(
-                    jinja_env.from_string(revoke_privilege).render(
-                        privilege_clause=f"select on {info['sf_type']} {info['db']}.{info['schema']}.{info['name']}",
-                        grantee_type="user",
-                        grantee_name=grantee,
+                        privilege_clause=f"{priv} on {obj_fqn}",
+                        grantee_type=gtype,
+                        grantee_name=name,
                     )
                 )
 

--- a/snowbird/plan.py
+++ b/snowbird/plan.py
@@ -1027,43 +1027,43 @@ def execution_plan(config: dict, state={}) -> list[str]:
 
 
 def overview(execution_plan: dict) -> dict:
-    create_databases = [s.split()[5] for s in execution_plan if "create database" in s]
+    create_databases = [s.split()[5] for s in execution_plan if s.startswith("create database")]
     create_transient_databases = [
-        s.split()[6] for s in execution_plan if "create transient database" in s
+        s.split()[6] for s in execution_plan if s.startswith("create transient database")
     ]
     create_databases.extend(create_transient_databases)
-    alter_databases = [s.split()[2] for s in execution_plan if "alter database" in s]
+    alter_databases = [s.split()[2] for s in execution_plan if s.startswith("alter database")]
     modify_databases = [d for d in alter_databases if d not in create_databases]
 
-    create_schemas = [s.split()[5] for s in execution_plan if "create schema" in s]
+    create_schemas = [s.split()[5] for s in execution_plan if s.startswith("create schema")]
     create_transient_schemas = [
-        s.split()[6] for s in execution_plan if "create transient schema" in s
+        s.split()[6] for s in execution_plan if s.startswith("create transient schema")
     ]
     create_schemas.extend(create_transient_schemas)
-    alter_schemas = [s for s in execution_plan if "alter schema" in s]
+    alter_schemas = [s for s in execution_plan if s.startswith("alter schema")]
     modify_schemas = [
         s.split()[2] for s in alter_schemas if s.split()[2] not in create_schemas
     ]
 
-    create_roles = [s.split()[5] for s in execution_plan if "create role" in s]
-    alter_roles = [s.split()[2] for s in execution_plan if "alter role" in s]
+    create_roles = [s.split()[5] for s in execution_plan if s.startswith("create role")]
+    alter_roles = [s.split()[2] for s in execution_plan if s.startswith("alter role")]
     modify_roles = [r for r in alter_roles if r not in create_roles]
 
-    create_users = [s.split()[5] for s in execution_plan if "create user" in s]
-    alter_users = [s.split()[2] for s in execution_plan if "alter user" in s]
+    create_users = [s.split()[5] for s in execution_plan if s.startswith("create user")]
+    alter_users = [s.split()[2] for s in execution_plan if s.startswith("alter user")]
     modify_users = [u for u in alter_users if u not in create_users]
 
     create_warehouses = [
-        s.split()[5] for s in execution_plan if "create warehouse" in s
+        s.split()[5] for s in execution_plan if s.startswith("create warehouse")
     ]
-    alter_warehouses = [s.split()[2] for s in execution_plan if "alter warehouse" in s]
+    alter_warehouses = [s.split()[2] for s in execution_plan if s.startswith("alter warehouse")]
     modify_warehouses = [w for w in alter_warehouses if w not in create_warehouses]
 
     create_network_policies = [
-        s.split()[6] for s in execution_plan if "create network policy" in s
+        s.split()[6] for s in execution_plan if s.startswith("create network policy")
     ]
     alter_network_policies = [
-        s.split()[3] for s in execution_plan if "alter network policy" in s
+        s.split()[3] for s in execution_plan if s.startswith("alter network policy")
     ]
     modify_network_policies = [
         s for s in alter_network_policies if s not in create_network_policies

--- a/snowbird/plan.py
+++ b/snowbird/plan.py
@@ -72,83 +72,44 @@ alter_network_policy = """
 grant_role_usage_on_warehouse = """
     grant usage on warehouse {{ warehouse }} to role {{ role }}
 """
-revoke_role_usage_on_warehouse = """
-    revoke usage on warehouse {{ warehouse }} from role {{ role }}
-"""
-revoke_privilege_on_resource = """
-    revoke {{ privilege }} on {{ resource_type }} {{ name }} from role {{ role }}
-"""
 grant_role_usage_on_database = """
     grant usage on database {{ database }} to role {{ role }}
-"""
-revoke_role_usage_on_database = """
-    revoke usage on database {{ database }} from role {{ role }}
 """
 grant_role_usage_on_schema = """
     grant usage on schema {{ database }}.{{ schema }} to role {{ role }}
 """
-revoke_role_usage_on_schema = """
-    revoke usage on schema {{ database }}.{{ schema }} from role {{ role }}
-"""
 grant_role_create_on_schema = """
     grant create {{ type }} on schema {{ database }}.{{ schema }} to role {{ role }}
-"""
-revoke_role_create_on_schema = """
-    revoke create {{ type }} on schema {{ database }}.{{ schema }} from role {{ role }}
 """
 grant_role_read_on_tables_in_schema = """
     grant select on all tables in schema {{ database }}.{{ schema }} to role {{ role }}
 """
-revoke_role_read_on_tables_in_schema = """
-    revoke select on all tables in schema {{ database }}.{{ schema }} from role {{ role }}
-"""
 grant_role_future_read_on_tables_in_schema = """
     grant select on future tables in schema {{ database }}.{{ schema }} to role {{ role }}
-"""
-revoke_role_future_read_on_tables_in_schema = """
-    revoke select on future tables in schema {{ database }}.{{ schema }} from role {{ role }}
 """
 grant_role_read_on_views_in_schema = """
     grant select on all views in schema {{ database }}.{{ schema }} to role {{ role }}
 """
-revoke_role_read_on_views_in_schema = """
-    revoke select on all views in schema {{ database }}.{{ schema }} from role {{ role }}
-"""
 grant_role_future_read_on_views_in_schema = """
     grant select on future views in schema {{ database }}.{{ schema }} to role {{ role }}
-"""
-revoke_role_future_read_on_views_in_schema = """
-    revoke select on future views in schema {{ database }}.{{ schema }} from role {{ role }}
 """
 grant_role_read_on_dynamic_tables_in_schema = """
     grant select on all dynamic tables in schema {{ database }}.{{ schema }} to role {{ role }}
 """
-revoke_role_read_on_dynamic_tables_in_schema = """
-    revoke select on all dynamic tables in schema {{ database }}.{{ schema }} from role {{ role }}
-"""
 grant_role_future_read_on_dynamic_tables_in_schema = """
     grant select on future dynamic tables in schema {{ database }}.{{ schema }} to role {{ role }}
-"""
-revoke_role_future_read_on_dynamic_tables_in_schema = """
-    revoke select on future dynamic tables in schema {{ database }}.{{ schema }} from role {{ role }}
 """
 grant_role_read_on_semantic_views_in_schema = """
     grant select on all semantic views in schema {{ database }}.{{ schema }} to role {{ role }}
 """
-revoke_role_read_on_semantic_views_in_schema = """
-    revoke select on all semantic views in schema {{ database }}.{{ schema }} from role {{ role }}
-"""
 grant_role_future_read_on_semantic_views_in_schema = """
     grant select on future semantic views in schema {{ database }}.{{ schema }} to role {{ role }}
-"""
-revoke_role_future_read_on_semantic_views_in_schema = """
-    revoke select on future semantic views in schema {{ database }}.{{ schema }} from role {{ role }}
 """
 grant_role_select_on_object = """
     grant select on {{ object_type }} {{ database }}.{{ schema }}.{{ object_name }} to role {{ role }}
 """
-revoke_role_select_on_object = """
-    revoke select on {{ object_type }} {{ database }}.{{ schema }}.{{ object_name }} from role {{ role }}
+revoke_privilege = """
+    revoke {{ privilege_clause }} from {{ grantee_type }} "{{ grantee_name.upper() }}"
 """
 grant_role_to_user = """
     grant role {{ role }} to user "{{ to_user.upper() }}"
@@ -459,9 +420,7 @@ def _grant_role_execution_plan(grants: list[dict], state: dict) -> list[str]:
             database, schema, name = parts
             config_key = object_entry
             desired_database_roles.setdefault(database, set()).add(role)
-            desired_schema_roles.setdefault(
-                f"{database}.{schema}", set()
-            ).add(role)
+            desired_schema_roles.setdefault(f"{database}.{schema}", set()).add(role)
             if config_key not in desired_object_read:
                 desired_object_read[config_key] = {
                     "roles": set(),
@@ -485,31 +444,52 @@ def _grant_role_execution_plan(grants: list[dict], state: dict) -> list[str]:
                 )
                 execution_plan.add(stmt)
         else:
-            actual_roles = {
+            actual_role_grantees = {
                 g["grantee_name"].lower()
                 for g in warehouse_grant_state
                 if g["privilege"].lower() == "usage"
+                and g.get("granted_to", "ROLE").lower() == "role"
             }
-            for role in desired_roles - actual_roles:
+            actual_user_grantees = {
+                g["grantee_name"].lower()
+                for g in warehouse_grant_state
+                if g["privilege"].lower() == "usage"
+                and g.get("granted_to", "ROLE").lower() == "user"
+            }
+            for role in desired_roles - actual_role_grantees:
                 stmt = jinja_env.from_string(grant_role_usage_on_warehouse).render(
                     role=role, warehouse=warehouse
                 )
                 execution_plan.add(stmt)
-            for role in actual_roles - desired_roles:
-                stmt = jinja_env.from_string(revoke_role_usage_on_warehouse).render(
-                    role=role, warehouse=warehouse
+            for grantee in actual_role_grantees - desired_roles:
+                execution_plan.add(
+                    jinja_env.from_string(revoke_privilege).render(
+                        privilege_clause=f"usage on warehouse {warehouse}",
+                        grantee_type="role",
+                        grantee_name=grantee,
+                    )
                 )
-                execution_plan.add(stmt)
+            for grantee in actual_user_grantees:
+                execution_plan.add(
+                    jinja_env.from_string(revoke_privilege).render(
+                        privilege_clause=f"usage on warehouse {warehouse}",
+                        grantee_type="user",
+                        grantee_name=grantee,
+                    )
+                )
             # Revoke unmanaged privileges (anything that isn't USAGE or OWNERSHIP)
             for g in warehouse_grant_state:
                 priv = g["privilege"].lower()
-                if priv not in ("usage", "ownership"):
+                grantee_type = g.get("granted_to", "ROLE").lower()
+                if priv not in ("usage", "ownership") and grantee_type in (
+                    "role",
+                    "user",
+                ):
                     execution_plan.add(
-                        jinja_env.from_string(revoke_privilege_on_resource).render(
-                            privilege=priv,
-                            resource_type="warehouse",
-                            name=warehouse,
-                            role=g["grantee_name"].lower(),
+                        jinja_env.from_string(revoke_privilege).render(
+                            privilege_clause=f"{priv} on warehouse {warehouse}",
+                            grantee_type=grantee_type,
+                            grantee_name=g["grantee_name"].lower(),
                         )
                     )
 
@@ -525,33 +505,53 @@ def _grant_role_execution_plan(grants: list[dict], state: dict) -> list[str]:
                     )
                 )
         else:
-            actual_roles = {
+            actual_role_grantees = {
                 g["grantee_name"].lower()
                 for g in db_grant_state
                 if g["privilege"].lower() == "usage"
+                and g.get("granted_to", "ROLE").lower() == "role"
             }
-            for role in desired_roles - actual_roles:
+            actual_user_grantees = {
+                g["grantee_name"].lower()
+                for g in db_grant_state
+                if g["privilege"].lower() == "usage"
+                and g.get("granted_to", "ROLE").lower() == "user"
+            }
+            for role in desired_roles - actual_role_grantees:
                 execution_plan.add(
                     jinja_env.from_string(grant_role_usage_on_database).render(
                         role=role, database=database
                     )
                 )
-            for role in actual_roles - desired_roles:
+            for grantee in actual_role_grantees - desired_roles:
                 execution_plan.add(
-                    jinja_env.from_string(revoke_role_usage_on_database).render(
-                        role=role, database=database
+                    jinja_env.from_string(revoke_privilege).render(
+                        privilege_clause=f"usage on database {database}",
+                        grantee_type="role",
+                        grantee_name=grantee,
+                    )
+                )
+            for grantee in actual_user_grantees:
+                execution_plan.add(
+                    jinja_env.from_string(revoke_privilege).render(
+                        privilege_clause=f"usage on database {database}",
+                        grantee_type="user",
+                        grantee_name=grantee,
                     )
                 )
             # Revoke unmanaged privileges
             for g in db_grant_state:
                 priv = g["privilege"].lower()
-                if priv not in ("usage", "ownership"):
+                grantee_type = g.get("granted_to", "ROLE").lower()
+                if priv not in ("usage", "ownership") and grantee_type in (
+                    "role",
+                    "user",
+                ):
                     execution_plan.add(
-                        jinja_env.from_string(revoke_privilege_on_resource).render(
-                            privilege=priv,
-                            resource_type="database",
-                            name=database,
-                            role=g["grantee_name"].lower(),
+                        jinja_env.from_string(revoke_privilege).render(
+                            privilege_clause=f"{priv} on database {database}",
+                            grantee_type=grantee_type,
+                            grantee_name=g["grantee_name"].lower(),
                         )
                     )
 
@@ -579,21 +579,38 @@ def _grant_role_execution_plan(grants: list[dict], state: dict) -> list[str]:
                     )
                 )
         else:
-            actual_roles = {
+            actual_role_grantees = {
                 g["grantee_name"].lower()
                 for g in schema_grant_state
                 if g["privilege"].lower() == "usage"
+                and g.get("granted_to", "ROLE").lower() == "role"
             }
-            for role in desired_roles - actual_roles:
+            actual_user_grantees = {
+                g["grantee_name"].lower()
+                for g in schema_grant_state
+                if g["privilege"].lower() == "usage"
+                and g.get("granted_to", "ROLE").lower() == "user"
+            }
+            for role in desired_roles - actual_role_grantees:
                 execution_plan.add(
                     jinja_env.from_string(grant_role_usage_on_schema).render(
                         role=role, database=database, schema=schema
                     )
                 )
-            for role in actual_roles - desired_roles:
+            for grantee in actual_role_grantees - desired_roles:
                 execution_plan.add(
-                    jinja_env.from_string(revoke_role_usage_on_schema).render(
-                        role=role, database=database, schema=schema
+                    jinja_env.from_string(revoke_privilege).render(
+                        privilege_clause=f"usage on schema {database}.{schema}",
+                        grantee_type="role",
+                        grantee_name=grantee,
+                    )
+                )
+            for grantee in actual_user_grantees:
+                execution_plan.add(
+                    jinja_env.from_string(revoke_privilege).render(
+                        privilege_clause=f"usage on schema {database}.{schema}",
+                        grantee_type="user",
+                        grantee_name=grantee,
                     )
                 )
             # Revoke unmanaged privileges (not USAGE, not CREATE types, not OWNERSHIP)
@@ -602,42 +619,33 @@ def _grant_role_execution_plan(grants: list[dict], state: dict) -> list[str]:
                 managed_schema_privs.add(f"create {ct}")
             for g in schema_grant_state:
                 priv = g["privilege"].lower()
-                if priv not in managed_schema_privs:
+                grantee_type = g.get("granted_to", "ROLE").lower()
+                if priv not in managed_schema_privs and grantee_type in (
+                    "role",
+                    "user",
+                ):
                     execution_plan.add(
-                        jinja_env.from_string(revoke_privilege_on_resource).render(
-                            privilege=priv,
-                            resource_type="schema",
-                            name=schema_path,
-                            role=g["grantee_name"].lower(),
+                        jinja_env.from_string(revoke_privilege).render(
+                            privilege_clause=f"{priv} on schema {schema_path}",
+                            grantee_type=grantee_type,
+                            grantee_name=g["grantee_name"].lower(),
                         )
                     )
 
     # --- Future read grants (read_on_schemas) ---
     future_in_schemas_state = state.get("future_in_schemas", {})
     future_grant_types = [
-        (
-            "table",
-            grant_role_future_read_on_tables_in_schema,
-            revoke_role_future_read_on_tables_in_schema,
-            revoke_role_read_on_tables_in_schema,
-        ),
-        (
-            "view",
-            grant_role_future_read_on_views_in_schema,
-            revoke_role_future_read_on_views_in_schema,
-            revoke_role_read_on_views_in_schema,
-        ),
+        ("table", grant_role_future_read_on_tables_in_schema, "tables"),
+        ("view", grant_role_future_read_on_views_in_schema, "views"),
         (
             "dynamic table",
             grant_role_future_read_on_dynamic_tables_in_schema,
-            revoke_role_future_read_on_dynamic_tables_in_schema,
-            revoke_role_read_on_dynamic_tables_in_schema,
+            "dynamic tables",
         ),
         (
             "semantic view",
             grant_role_future_read_on_semantic_views_in_schema,
-            revoke_role_future_read_on_semantic_views_in_schema,
-            revoke_role_read_on_semantic_views_in_schema,
+            "semantic views",
         ),
     ]
     # Track (schema_path, role) pairs that need new future grants — these also
@@ -646,7 +654,7 @@ def _grant_role_execution_plan(grants: list[dict], state: dict) -> list[str]:
     for schema_path, desired_roles in desired_future_read.items():
         database, schema = schema_path.split(".")
         future_schema_state = future_in_schemas_state.get(schema_path)
-        for grant_on_type, grant_tmpl, revoke_future_tmpl, revoke_all_tmpl in future_grant_types:
+        for grant_on_type, grant_tmpl, type_plural in future_grant_types:
             if future_schema_state is None:
                 for role in desired_roles:
                     schemas_needing_bootstrap.add((schema_path, role))
@@ -656,29 +664,33 @@ def _grant_role_execution_plan(grants: list[dict], state: dict) -> list[str]:
                         )
                     )
             else:
-                actual_roles = {
+                actual_role_grantees = {
                     g["grantee_name"].lower()
                     for g in future_schema_state
                     if g["privilege"].lower() == "select"
                     and g["grant_on"].lower().replace("_", " ") == grant_on_type
                 }
-                for role in desired_roles - actual_roles:
+                for role in desired_roles - actual_role_grantees:
                     schemas_needing_bootstrap.add((schema_path, role))
                     execution_plan.add(
                         jinja_env.from_string(grant_tmpl).render(
                             role=role, database=database, schema=schema
                         )
                     )
-                for role in actual_roles - desired_roles:
+                for grantee in actual_role_grantees - desired_roles:
                     execution_plan.add(
-                        jinja_env.from_string(revoke_future_tmpl).render(
-                            role=role, database=database, schema=schema
+                        jinja_env.from_string(revoke_privilege).render(
+                            privilege_clause=f"select on future {type_plural} in schema {database}.{schema}",
+                            grantee_type="role",
+                            grantee_name=grantee,
                         )
                     )
                     # Also revoke on existing objects to clean up
                     execution_plan.add(
-                        jinja_env.from_string(revoke_all_tmpl).render(
-                            role=role, database=database, schema=schema
+                        jinja_env.from_string(revoke_privilege).render(
+                            privilege_clause=f"select on all {type_plural} in schema {database}.{schema}",
+                            grantee_type="role",
+                            grantee_name=grantee,
                         )
                     )
 
@@ -699,12 +711,19 @@ def _grant_role_execution_plan(grants: list[dict], state: dict) -> list[str]:
                         )
                     )
             else:
-                actual_roles = {
+                actual_role_grantees = {
                     g["grantee_name"].lower()
                     for g in schema_grant_state
                     if g["privilege"].lower() == privilege_name
+                    and g.get("granted_to", "ROLE").lower() == "role"
                 }
-                for role in desired_roles - actual_roles:
+                actual_user_grantees = {
+                    g["grantee_name"].lower()
+                    for g in schema_grant_state
+                    if g["privilege"].lower() == privilege_name
+                    and g.get("granted_to", "").lower() == "user"
+                }
+                for role in desired_roles - actual_role_grantees:
                     execution_plan.add(
                         jinja_env.from_string(grant_role_create_on_schema).render(
                             type=create_type,
@@ -713,13 +732,20 @@ def _grant_role_execution_plan(grants: list[dict], state: dict) -> list[str]:
                             schema=schema,
                         )
                     )
-                for role in actual_roles - desired_roles:
+                for grantee in actual_role_grantees - desired_roles:
                     execution_plan.add(
-                        jinja_env.from_string(revoke_role_create_on_schema).render(
-                            type=create_type,
-                            role=role,
-                            database=database,
-                            schema=schema,
+                        jinja_env.from_string(revoke_privilege).render(
+                            privilege_clause=f"create {create_type} on schema {database}.{schema}",
+                            grantee_type="role",
+                            grantee_name=grantee,
+                        )
+                    )
+                for grantee in actual_user_grantees:
+                    execution_plan.add(
+                        jinja_env.from_string(revoke_privilege).render(
+                            privilege_clause=f"create {create_type} on schema {database}.{schema}",
+                            grantee_type="user",
+                            grantee_name=grantee,
                         )
                     )
 
@@ -747,12 +773,19 @@ def _grant_role_execution_plan(grants: list[dict], state: dict) -> list[str]:
                     )
                 )
         else:
-            actual_roles = {
+            actual_role_grantees = {
                 g["grantee_name"].lower()
                 for g in obj_state
                 if g["privilege"].lower() == "select"
+                and g.get("granted_to", "ROLE").lower() == "role"
             }
-            for role in explicitly_desired - actual_roles:
+            actual_user_grantees = {
+                g["grantee_name"].lower()
+                for g in obj_state
+                if g["privilege"].lower() == "select"
+                and g.get("granted_to", "").lower() == "user"
+            }
+            for role in explicitly_desired - actual_role_grantees:
                 execution_plan.add(
                     jinja_env.from_string(grant_role_select_on_object).render(
                         role=role,
@@ -762,14 +795,20 @@ def _grant_role_execution_plan(grants: list[dict], state: dict) -> list[str]:
                         object_name=info["name"],
                     )
                 )
-            for role in actual_roles - expanded_desired:
+            for grantee in actual_role_grantees - expanded_desired:
                 execution_plan.add(
-                    jinja_env.from_string(revoke_role_select_on_object).render(
-                        role=role,
-                        object_type=info["sf_type"],
-                        database=info["db"],
-                        schema=info["schema"],
-                        object_name=info["name"],
+                    jinja_env.from_string(revoke_privilege).render(
+                        privilege_clause=f"select on {info['sf_type']} {info['db']}.{info['schema']}.{info['name']}",
+                        grantee_type="role",
+                        grantee_name=grantee,
+                    )
+                )
+            for grantee in actual_user_grantees:
+                execution_plan.add(
+                    jinja_env.from_string(revoke_privilege).render(
+                        privilege_clause=f"select on {info['sf_type']} {info['db']}.{info['schema']}.{info['name']}",
+                        grantee_type="user",
+                        grantee_name=grantee,
                     )
                 )
 
@@ -1146,29 +1185,21 @@ def overview(execution_plan: dict) -> dict:
         s for s in alter_network_policies if s not in create_network_policies
     ]
 
-    grant_selects = [s for s in execution_plan if "grant select on" in s and "in schema" in s]
-    grant_select_on_objects = [s for s in execution_plan if "grant select on" in s and "in schema" not in s]
+    grant_selects = [
+        s for s in execution_plan if "grant select on" in s and "in schema" in s
+    ]
+    grant_select_on_objects = [
+        s for s in execution_plan if "grant select on" in s and "in schema" not in s
+    ]
     grant_create = [s for s in execution_plan if "grant create" in s]
     grant_roles = [s for s in execution_plan if "grant role" in s and "to role" in s]
     grant_users = [s for s in execution_plan if "grant role" in s and "to user" in s]
-    grant_warehouses = [
-        s for s in execution_plan if "grant usage on warehouse" in s
-    ]
-    grant_databases = [
-        s for s in execution_plan if "grant usage on database" in s
-    ]
-    grant_schemas = [
-        s for s in execution_plan if "grant usage on schema" in s
-    ]
-    revoke_warehouses = [
-        s for s in execution_plan if "revoke usage on warehouse" in s
-    ]
-    revoke_databases = [
-        s for s in execution_plan if "revoke usage on database" in s
-    ]
-    revoke_schemas = [
-        s for s in execution_plan if "revoke usage on schema" in s
-    ]
+    grant_warehouses = [s for s in execution_plan if "grant usage on warehouse" in s]
+    grant_databases = [s for s in execution_plan if "grant usage on database" in s]
+    grant_schemas = [s for s in execution_plan if "grant usage on schema" in s]
+    revoke_warehouses = [s for s in execution_plan if "revoke usage on warehouse" in s]
+    revoke_databases = [s for s in execution_plan if "revoke usage on database" in s]
+    revoke_schemas = [s for s in execution_plan if "revoke usage on schema" in s]
     revoke_selects = [
         s for s in execution_plan if "revoke select on" in s and "in schema" in s
     ]

--- a/tests/test_execution_plan.py
+++ b/tests/test_execution_plan.py
@@ -2111,3 +2111,203 @@ def test_unmanaged_privilege_revoked_with_correct_grantee_type():
     result = set(execution_plan(config=config, state=state))
     assert 'revoke operate on warehouse wh1 from user "SOME_USER"' in result
     assert not any('from role "SOME_USER"' in s for s in result)
+
+
+def test_schema_single_pass_revokes_mixed_privileges():
+    """Schema diff revokes usage, create, and unmanaged privs in a single pass."""
+    config = {
+        "grants": [
+            {"role": "reader", "read_on_schemas": ["db1.sch1"]},
+        ]
+    }
+    state = {
+        "grants": {
+            "on_databases": {},
+            "on_schemas": {
+                "db1.sch1": [
+                    {
+                        "privilege": "USAGE",
+                        "grantee_name": "READER",
+                        "granted_to": "ROLE",
+                    },
+                    {
+                        "privilege": "USAGE",
+                        "grantee_name": "ROGUE",
+                        "granted_to": "ROLE",
+                    },
+                    {
+                        "privilege": "CREATE TABLE",
+                        "grantee_name": "ROGUE",
+                        "granted_to": "ROLE",
+                    },
+                    {
+                        "privilege": "MODIFY",
+                        "grantee_name": "ROGUE",
+                        "granted_to": "ROLE",
+                    },
+                    {
+                        "privilege": "MONITOR",
+                        "grantee_name": "SOME_USER",
+                        "granted_to": "USER",
+                    },
+                    {
+                        "privilege": "OWNERSHIP",
+                        "grantee_name": "SYSADMIN",
+                        "granted_to": "ROLE",
+                    },
+                ]
+            },
+            "future_in_schemas": {},
+            "on_objects": {},
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert 'revoke usage on schema db1.sch1 from role "ROGUE"' in result
+    assert 'revoke create table on schema db1.sch1 from role "ROGUE"' in result
+    assert 'revoke modify on schema db1.sch1 from role "ROGUE"' in result
+    assert 'revoke monitor on schema db1.sch1 from user "SOME_USER"' in result
+    assert not any("revoke ownership" in s for s in result)
+    assert 'revoke usage on schema db1.sch1 from role "READER"' not in result
+
+
+def test_object_select_revokes_non_select_privileges():
+    """Object diff revokes non-select privileges dynamically from state."""
+    config = {
+        "grants": [
+            {"role": "reader", "read_on_objects": ["table:db1.sch1.tbl1"]},
+        ]
+    }
+    state = {
+        "grants": {
+            "on_databases": {},
+            "on_schemas": {},
+            "future_in_schemas": {},
+            "on_objects": {
+                "table:db1.sch1.tbl1": [
+                    {
+                        "privilege": "SELECT",
+                        "grantee_name": "READER",
+                        "granted_to": "ROLE",
+                    },
+                    {
+                        "privilege": "INSERT",
+                        "grantee_name": "WRITER",
+                        "granted_to": "ROLE",
+                    },
+                    {
+                        "privilege": "DELETE",
+                        "grantee_name": "SOME_USER",
+                        "granted_to": "USER",
+                    },
+                    {
+                        "privilege": "OWNERSHIP",
+                        "grantee_name": "SYSADMIN",
+                        "granted_to": "ROLE",
+                    },
+                ]
+            },
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert 'revoke insert on table db1.sch1.tbl1 from role "WRITER"' in result
+    assert 'revoke delete on table db1.sch1.tbl1 from user "SOME_USER"' in result
+    assert not any("revoke ownership" in s for s in result)
+    assert not any("READER" in s and "revoke" in s for s in result)
+
+
+def test_future_grants_revokes_non_select_privileges():
+    """Future grants diff revokes non-select privileges dynamically from state."""
+    config = {
+        "grants": [
+            {"role": "reader", "read_on_schemas": ["db1.sch1"]},
+        ]
+    }
+    state = {
+        "grants": {
+            "on_databases": {},
+            "on_schemas": {},
+            "future_in_schemas": {
+                "db1.sch1": [
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "TABLE",
+                        "grantee_name": "READER",
+                    },
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "VIEW",
+                        "grantee_name": "READER",
+                    },
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "DYNAMIC_TABLE",
+                        "grantee_name": "READER",
+                    },
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "SEMANTIC_VIEW",
+                        "grantee_name": "READER",
+                    },
+                    {
+                        "privilege": "INSERT",
+                        "grant_on": "TABLE",
+                        "grantee_name": "ROGUE",
+                    },
+                ]
+            },
+            "on_objects": {},
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert (
+        'revoke insert on future tables in schema db1.sch1 from role "ROGUE"' in result
+    )
+    assert 'revoke insert on all tables in schema db1.sch1 from role "ROGUE"' in result
+    assert not any("READER" in s and "revoke" in s for s in result)
+
+
+def test_future_grants_does_not_revoke_ownership():
+    """Future grants diff must never revoke OWNERSHIP."""
+    config = {
+        "grants": [
+            {"role": "reader", "read_on_schemas": ["db1.sch1"]},
+        ]
+    }
+    state = {
+        "grants": {
+            "on_databases": {},
+            "on_schemas": {},
+            "future_in_schemas": {
+                "db1.sch1": [
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "TABLE",
+                        "grantee_name": "READER",
+                    },
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "VIEW",
+                        "grantee_name": "READER",
+                    },
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "DYNAMIC_TABLE",
+                        "grantee_name": "READER",
+                    },
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "SEMANTIC_VIEW",
+                        "grantee_name": "READER",
+                    },
+                    {
+                        "privilege": "OWNERSHIP",
+                        "grant_on": "TABLE",
+                        "grantee_name": "SYSADMIN",
+                    },
+                ]
+            },
+            "on_objects": {},
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert not any("revoke ownership" in s for s in result)

--- a/tests/test_execution_plan.py
+++ b/tests/test_execution_plan.py
@@ -774,6 +774,7 @@ def test_grant_role_read_on_multiple_schemas():
     print(result)
     assert result == expected
 
+
 def test_grant_role_read_on_objects():
     config = {
         "grants": [
@@ -797,6 +798,7 @@ def test_grant_role_read_on_objects():
     assert not any("grant select on all tables" in s for s in result)
     assert not any("grant select on future tables" in s for s in result)
 
+
 def test_grant_role_read_on_objects_all_types():
     config = {
         "grants": [
@@ -817,6 +819,7 @@ def test_grant_role_read_on_objects_all_types():
     assert "grant select on dynamic table db.sch.dt1 to role foo" in result
     assert "grant select on semantic view db.sch.sv1 to role foo" in result
 
+
 def test_read_on_objects_invalid_type_prefix_raises_error():
     config = {
         "grants": [
@@ -829,6 +832,7 @@ def test_read_on_objects_invalid_type_prefix_raises_error():
     with pytest.raises(ValueError, match="Invalid input for object type"):
         execution_plan(config)
 
+
 def test_read_on_objects_missing_type_prefix_raises_error():
     config = {
         "grants": [
@@ -838,8 +842,12 @@ def test_read_on_objects_missing_type_prefix_raises_error():
             }
         ]
     }
-    with pytest.raises(ValueError, match="Invalid type_input, must contain exactly one colon between object type and name"):
+    with pytest.raises(
+        ValueError,
+        match="Invalid type_input, must contain exactly one colon between object type and name",
+    ):
         execution_plan(config)
+
 
 def test_read_on_objects_invalid_path_raises_error():
     config = {
@@ -850,8 +858,12 @@ def test_read_on_objects_invalid_path_raises_error():
             }
         ]
     }
-    with pytest.raises(ValueError, match="Invalid object path db.obj, must be in the format database.schema.object"):
+    with pytest.raises(
+        ValueError,
+        match="Invalid object path db.obj, must be in the format database.schema.object",
+    ):
         execution_plan(config)
+
 
 def test_grant_role_to_role():
     config = {"grants": [{"role": "foo", "to_roles": ["bar"]}]}
@@ -1029,11 +1041,7 @@ def test_grant_warehouse_skipped_when_already_exists():
 def test_grant_warehouse_when_not_in_state():
     config = {"grants": [{"role": "foo", "warehouses": ["bar"]}]}
     state = {
-        "grants": {
-            "on_warehouses": {
-                "bar": []
-            }
-        },
+        "grants": {"on_warehouses": {"bar": []}},
     }
     expected = {
         "use role useradmin",
@@ -1060,7 +1068,7 @@ def test_revoke_warehouse_from_unlisted_role():
     expected = {
         "use role useradmin",
         'grant role foo to role "SYSADMIN"',
-        "revoke usage on warehouse bar from role rogue_role",
+        'revoke usage on warehouse bar from role "ROGUE_ROLE"',
     }
     result = set(execution_plan(config=config, state=state))
     print(result)
@@ -1081,7 +1089,7 @@ def test_revoke_warehouse_when_not_in_config():
     expected = {
         "use role useradmin",
         "grant usage on warehouse bar to role foo",
-        "revoke usage on warehouse bar from role baz",
+        'revoke usage on warehouse bar from role "BAZ"',
         'grant role foo to role "SYSADMIN"',
     }
     result = set(execution_plan(config=config, state=state))
@@ -1109,7 +1117,7 @@ def test_grant_and_revoke_warehouse_mixed():
     expected = {
         "use role useradmin",
         "grant usage on warehouse wh2 to role foo",
-        "revoke usage on warehouse wh1 from role old_role",
+        'revoke usage on warehouse wh1 from role "OLD_ROLE"',
         'grant role foo to role "SYSADMIN"',
     }
     result = set(execution_plan(config=config, state=state))
@@ -1136,7 +1144,7 @@ def test_warehouse_grants_aggregated_across_entries():
     result = set(execution_plan(config=config, state=state))
     assert "grant usage on warehouse wh1 to role foo" in result
     assert "grant usage on warehouse wh1 to role bar" in result
-    assert "revoke usage on warehouse wh1 from role old_role" in result
+    assert 'revoke usage on warehouse wh1 from role "OLD_ROLE"' in result
 
 
 def test_warehouse_ownership_not_revoked():
@@ -1181,15 +1189,23 @@ def test_database_usage_skipped_when_already_exists():
                 "db1.sch1": [
                     {"privilege": "SELECT", "grant_on": "TABLE", "grantee_name": "FOO"},
                     {"privilege": "SELECT", "grant_on": "VIEW", "grantee_name": "FOO"},
-                    {"privilege": "SELECT", "grant_on": "DYNAMIC TABLE", "grantee_name": "FOO"},
-                    {"privilege": "SELECT", "grant_on": "SEMANTIC VIEW", "grantee_name": "FOO"},
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "DYNAMIC TABLE",
+                        "grantee_name": "FOO",
+                    },
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "SEMANTIC VIEW",
+                        "grantee_name": "FOO",
+                    },
                 ]
             },
         },
     }
     result = set(execution_plan(config=config, state=state))
     assert "grant usage on database db1 to role foo" not in result
-    assert "revoke usage on database db1 from role foo" not in result
+    assert 'revoke usage on database db1 from role "FOO"' not in result
 
 
 def test_database_usage_granted_when_missing():
@@ -1221,7 +1237,7 @@ def test_database_usage_revoked_from_unlisted_role():
     }
     result = set(execution_plan(config=config, state=state))
     assert "grant usage on database db1 to role foo" not in result
-    assert "revoke usage on database db1 from role rogue" in result
+    assert 'revoke usage on database db1 from role "ROGUE"' in result
 
 
 def test_database_usage_aggregated_across_read_and_write():
@@ -1245,7 +1261,7 @@ def test_database_usage_aggregated_across_read_and_write():
     result = set(execution_plan(config=config, state=state))
     assert "grant usage on database db1 to role reader" in result
     assert "grant usage on database db1 to role writer" in result
-    assert "revoke usage on database db1 from role old_role" in result
+    assert 'revoke usage on database db1 from role "OLD_ROLE"' in result
 
 
 # ===== Schema USAGE stateful tests =====
@@ -1283,7 +1299,7 @@ def test_schema_usage_revoked_from_unlisted_role():
         },
     }
     result = set(execution_plan(config=config, state=state))
-    assert "revoke usage on schema db1.sch1 from role rogue" in result
+    assert 'revoke usage on schema db1.sch1 from role "ROGUE"' in result
 
 
 def test_schema_usage_aggregated_across_read_and_write():
@@ -1307,7 +1323,7 @@ def test_schema_usage_aggregated_across_read_and_write():
     result = set(execution_plan(config=config, state=state))
     assert "grant usage on schema db1.sch1 to role reader" in result
     assert "grant usage on schema db1.sch1 to role writer" in result
-    assert "revoke usage on schema db1.sch1 from role old_role" in result
+    assert 'revoke usage on schema db1.sch1 from role "OLD_ROLE"' in result
 
 
 def test_schema_usage_aggregated_from_read_on_objects():
@@ -1329,7 +1345,7 @@ def test_schema_usage_aggregated_from_read_on_objects():
     }
     result = set(execution_plan(config=config, state=state))
     assert "grant usage on schema db1.sch1 to role obj_reader" in result
-    assert "revoke usage on schema db1.sch1 from role rogue" in result
+    assert 'revoke usage on schema db1.sch1 from role "ROGUE"' in result
 
 
 # ===== Future read grants stateful tests =====
@@ -1345,8 +1361,16 @@ def test_future_read_skipped_when_already_exists():
                 "db1.sch1": [
                     {"privilege": "SELECT", "grant_on": "TABLE", "grantee_name": "FOO"},
                     {"privilege": "SELECT", "grant_on": "VIEW", "grantee_name": "FOO"},
-                    {"privilege": "SELECT", "grant_on": "DYNAMIC TABLE", "grantee_name": "FOO"},
-                    {"privilege": "SELECT", "grant_on": "SEMANTIC VIEW", "grantee_name": "FOO"},
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "DYNAMIC TABLE",
+                        "grantee_name": "FOO",
+                    },
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "SEMANTIC VIEW",
+                        "grantee_name": "FOO",
+                    },
                 ]
             },
         },
@@ -1354,8 +1378,14 @@ def test_future_read_skipped_when_already_exists():
     result = set(execution_plan(config=config, state=state))
     assert "grant select on future tables in schema db1.sch1 to role foo" not in result
     assert "grant select on future views in schema db1.sch1 to role foo" not in result
-    assert "grant select on future dynamic tables in schema db1.sch1 to role foo" not in result
-    assert "grant select on future semantic views in schema db1.sch1 to role foo" not in result
+    assert (
+        "grant select on future dynamic tables in schema db1.sch1 to role foo"
+        not in result
+    )
+    assert (
+        "grant select on future semantic views in schema db1.sch1 to role foo"
+        not in result
+    )
 
 
 def test_future_read_granted_when_missing():
@@ -1370,8 +1400,12 @@ def test_future_read_granted_when_missing():
     result = set(execution_plan(config=config, state=state))
     assert "grant select on future tables in schema db1.sch1 to role foo" in result
     assert "grant select on future views in schema db1.sch1 to role foo" in result
-    assert "grant select on future dynamic tables in schema db1.sch1 to role foo" in result
-    assert "grant select on future semantic views in schema db1.sch1 to role foo" in result
+    assert (
+        "grant select on future dynamic tables in schema db1.sch1 to role foo" in result
+    )
+    assert (
+        "grant select on future semantic views in schema db1.sch1 to role foo" in result
+    )
 
 
 def test_future_read_revoked_from_unlisted_role():
@@ -1383,28 +1417,68 @@ def test_future_read_revoked_from_unlisted_role():
             "future_in_schemas": {
                 "db1.sch1": [
                     {"privilege": "SELECT", "grant_on": "TABLE", "grantee_name": "FOO"},
-                    {"privilege": "SELECT", "grant_on": "TABLE", "grantee_name": "ROGUE"},
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "TABLE",
+                        "grantee_name": "ROGUE",
+                    },
                     {"privilege": "SELECT", "grant_on": "VIEW", "grantee_name": "FOO"},
-                    {"privilege": "SELECT", "grant_on": "VIEW", "grantee_name": "ROGUE"},
-                    {"privilege": "SELECT", "grant_on": "DYNAMIC TABLE", "grantee_name": "FOO"},
-                    {"privilege": "SELECT", "grant_on": "DYNAMIC TABLE", "grantee_name": "ROGUE"},
-                    {"privilege": "SELECT", "grant_on": "SEMANTIC VIEW", "grantee_name": "FOO"},
-                    {"privilege": "SELECT", "grant_on": "SEMANTIC VIEW", "grantee_name": "ROGUE"},
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "VIEW",
+                        "grantee_name": "ROGUE",
+                    },
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "DYNAMIC TABLE",
+                        "grantee_name": "FOO",
+                    },
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "DYNAMIC TABLE",
+                        "grantee_name": "ROGUE",
+                    },
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "SEMANTIC VIEW",
+                        "grantee_name": "FOO",
+                    },
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "SEMANTIC VIEW",
+                        "grantee_name": "ROGUE",
+                    },
                 ]
             },
         },
     }
     result = set(execution_plan(config=config, state=state))
     # Should revoke future grants for rogue
-    assert "revoke select on future tables in schema db1.sch1 from role rogue" in result
-    assert "revoke select on future views in schema db1.sch1 from role rogue" in result
-    assert "revoke select on future dynamic tables in schema db1.sch1 from role rogue" in result
-    assert "revoke select on future semantic views in schema db1.sch1 from role rogue" in result
+    assert (
+        'revoke select on future tables in schema db1.sch1 from role "ROGUE"' in result
+    )
+    assert (
+        'revoke select on future views in schema db1.sch1 from role "ROGUE"' in result
+    )
+    assert (
+        'revoke select on future dynamic tables in schema db1.sch1 from role "ROGUE"'
+        in result
+    )
+    assert (
+        'revoke select on future semantic views in schema db1.sch1 from role "ROGUE"'
+        in result
+    )
     # Should also revoke ALL grants to clean up existing objects
-    assert "revoke select on all tables in schema db1.sch1 from role rogue" in result
-    assert "revoke select on all views in schema db1.sch1 from role rogue" in result
-    assert "revoke select on all dynamic tables in schema db1.sch1 from role rogue" in result
-    assert "revoke select on all semantic views in schema db1.sch1 from role rogue" in result
+    assert 'revoke select on all tables in schema db1.sch1 from role "ROGUE"' in result
+    assert 'revoke select on all views in schema db1.sch1 from role "ROGUE"' in result
+    assert (
+        'revoke select on all dynamic tables in schema db1.sch1 from role "ROGUE"'
+        in result
+    )
+    assert (
+        'revoke select on all semantic views in schema db1.sch1 from role "ROGUE"'
+        in result
+    )
     # Should NOT revoke foo
     assert not any("revoke" in s and "foo" in s for s in result)
 
@@ -1428,8 +1502,16 @@ def test_all_grants_skipped_when_future_grants_already_exist():
                 "db1.sch1": [
                     {"privilege": "SELECT", "grant_on": "TABLE", "grantee_name": "FOO"},
                     {"privilege": "SELECT", "grant_on": "VIEW", "grantee_name": "FOO"},
-                    {"privilege": "SELECT", "grant_on": "DYNAMIC TABLE", "grantee_name": "FOO"},
-                    {"privilege": "SELECT", "grant_on": "SEMANTIC VIEW", "grantee_name": "FOO"},
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "DYNAMIC TABLE",
+                        "grantee_name": "FOO",
+                    },
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "SEMANTIC VIEW",
+                        "grantee_name": "FOO",
+                    },
                 ]
             },
         },
@@ -1438,8 +1520,14 @@ def test_all_grants_skipped_when_future_grants_already_exist():
     # ALL grants should NOT be emitted when future grants are already in place
     assert "grant select on all tables in schema db1.sch1 to role foo" not in result
     assert "grant select on all views in schema db1.sch1 to role foo" not in result
-    assert "grant select on all dynamic tables in schema db1.sch1 to role foo" not in result
-    assert "grant select on all semantic views in schema db1.sch1 to role foo" not in result
+    assert (
+        "grant select on all dynamic tables in schema db1.sch1 to role foo"
+        not in result
+    )
+    assert (
+        "grant select on all semantic views in schema db1.sch1 to role foo"
+        not in result
+    )
 
 
 def test_all_grants_skipped_with_underscored_grant_on():
@@ -1447,27 +1535,43 @@ def test_all_grants_skipped_with_underscored_grant_on():
     config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
     state = {
         "grants": {
-            "on_databases": {
-                "db1": [{"privilege": "USAGE", "grantee_name": "FOO"}]
-            },
-            "on_schemas": {
-                "db1.sch1": [{"privilege": "USAGE", "grantee_name": "FOO"}]
-            },
+            "on_databases": {"db1": [{"privilege": "USAGE", "grantee_name": "FOO"}]},
+            "on_schemas": {"db1.sch1": [{"privilege": "USAGE", "grantee_name": "FOO"}]},
             "future_in_schemas": {
                 "db1.sch1": [
                     {"privilege": "SELECT", "grant_on": "TABLE", "grantee_name": "FOO"},
                     {"privilege": "SELECT", "grant_on": "VIEW", "grantee_name": "FOO"},
-                    {"privilege": "SELECT", "grant_on": "DYNAMIC_TABLE", "grantee_name": "FOO"},
-                    {"privilege": "SELECT", "grant_on": "SEMANTIC_VIEW", "grantee_name": "FOO"},
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "DYNAMIC_TABLE",
+                        "grantee_name": "FOO",
+                    },
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "SEMANTIC_VIEW",
+                        "grantee_name": "FOO",
+                    },
                 ]
             },
         },
     }
     result = set(execution_plan(config=config, state=state))
-    assert "grant select on future dynamic tables in schema db1.sch1 to role foo" not in result
-    assert "grant select on future semantic views in schema db1.sch1 to role foo" not in result
-    assert "grant select on all dynamic tables in schema db1.sch1 to role foo" not in result
-    assert "grant select on all semantic views in schema db1.sch1 to role foo" not in result
+    assert (
+        "grant select on future dynamic tables in schema db1.sch1 to role foo"
+        not in result
+    )
+    assert (
+        "grant select on future semantic views in schema db1.sch1 to role foo"
+        not in result
+    )
+    assert (
+        "grant select on all dynamic tables in schema db1.sch1 to role foo"
+        not in result
+    )
+    assert (
+        "grant select on all semantic views in schema db1.sch1 to role foo"
+        not in result
+    )
 
 
 def test_all_grants_emitted_when_future_grants_missing():
@@ -1545,8 +1649,8 @@ def test_create_grants_revoked_from_unlisted_role():
         },
     }
     result = set(execution_plan(config=config, state=state))
-    assert "revoke create table on schema db1.sch1 from role rogue" in result
-    assert "revoke create view on schema db1.sch1 from role rogue" in result
+    assert 'revoke create table on schema db1.sch1 from role "ROGUE"' in result
+    assert 'revoke create view on schema db1.sch1 from role "ROGUE"' in result
     assert not any("revoke create" in s and "foo" in s for s in result)
 
 
@@ -1617,7 +1721,7 @@ def test_object_select_revoked_from_unlisted_role():
         },
     }
     result = set(execution_plan(config=config, state=state))
-    assert "revoke select on table db1.sch1.t1 from role rogue" in result
+    assert 'revoke select on table db1.sch1.t1 from role "ROGUE"' in result
     assert not any("revoke" in s and "foo" in s for s in result)
 
 
@@ -1643,8 +1747,12 @@ def test_object_select_not_revoked_when_covered_by_read_on_schemas():
         },
     }
     result = set(execution_plan(config=config, state=state))
-    assert not any("revoke" in s and "analyst" in s and "db1.sch1.t1" in s for s in result)
-    assert not any("revoke" in s and "special" in s and "db1.sch1.t1" in s for s in result)
+    assert not any(
+        "revoke" in s and "analyst" in s and "db1.sch1.t1" in s for s in result
+    )
+    assert not any(
+        "revoke" in s and "special" in s and "db1.sch1.t1" in s for s in result
+    )
 
 
 def test_object_select_revoked_when_not_covered_by_schema_or_object():
@@ -1670,7 +1778,7 @@ def test_object_select_revoked_when_not_covered_by_schema_or_object():
         },
     }
     result = set(execution_plan(config=config, state=state))
-    assert "revoke select on table db1.sch1.t1 from role rogue" in result
+    assert 'revoke select on table db1.sch1.t1 from role "ROGUE"' in result
 
 
 # ===== Stateless mode compatibility =====
@@ -1727,7 +1835,9 @@ def test_database_ownership_transferred_when_wrong_owner():
         ],
     }
     result = set(execution_plan(config=config, state=state))
-    assert "grant ownership on database db1 to role sysadmin copy current grants" in result
+    assert (
+        "grant ownership on database db1 to role sysadmin copy current grants" in result
+    )
 
 
 def test_database_ownership_not_checked_when_new():
@@ -1822,10 +1932,10 @@ def test_unmanaged_privilege_revoked_on_database():
         },
     }
     result = set(execution_plan(config=config, state=state))
-    assert "revoke modify on database db1 from role bar" in result
-    assert "revoke monitor on database db1 from role baz" in result
+    assert 'revoke modify on database db1 from role "BAR"' in result
+    assert 'revoke monitor on database db1 from role "BAZ"' in result
     assert not any("revoke ownership" in s for s in result)
-    assert "revoke usage on database db1 from role foo" not in result
+    assert 'revoke usage on database db1 from role "FOO"' not in result
 
 
 def test_unmanaged_privilege_revoked_on_warehouse():
@@ -1843,10 +1953,10 @@ def test_unmanaged_privilege_revoked_on_warehouse():
         },
     }
     result = set(execution_plan(config=config, state=state))
-    assert "revoke operate on warehouse wh1 from role foo" in result
-    assert "revoke modify on warehouse wh1 from role bar" in result
+    assert 'revoke operate on warehouse wh1 from role "FOO"' in result
+    assert 'revoke modify on warehouse wh1 from role "BAR"' in result
     assert not any("revoke ownership" in s for s in result)
-    assert "revoke usage on warehouse wh1 from role foo" not in result
+    assert 'revoke usage on warehouse wh1 from role "FOO"' not in result
 
 
 def test_unmanaged_privilege_revoked_on_schema():
@@ -1873,10 +1983,10 @@ def test_unmanaged_privilege_revoked_on_schema():
         },
     }
     result = set(execution_plan(config=config, state=state))
-    assert "revoke modify on schema db1.sch1 from role baz" in result
+    assert 'revoke modify on schema db1.sch1 from role "BAZ"' in result
     assert not any("revoke ownership" in s for s in result)
-    assert "revoke usage on schema db1.sch1 from role foo" not in result
-    assert "revoke create table on schema db1.sch1 from role bar" not in result
+    assert 'revoke usage on schema db1.sch1 from role "FOO"' not in result
+    assert 'revoke create table on schema db1.sch1 from role "BAR"' not in result
 
 
 def test_unmanaged_privilege_not_revoked_without_state():
@@ -1884,3 +1994,120 @@ def test_unmanaged_privilege_not_revoked_without_state():
     config = {"grants": [{"role": "foo", "warehouses": ["wh1"]}]}
     result = set(execution_plan(config=config))
     assert not any("revoke" in s for s in result)
+
+
+# ===== User grantee handling tests =====
+
+
+def test_revoke_warehouse_usage_from_user_grantee():
+    """User-level resource grants are unmanaged and should be revoked with proper SQL."""
+    config = {"grants": [{"role": "foo", "warehouses": ["bar"]}]}
+    state = {
+        "grants": {
+            "on_warehouses": {
+                "bar": [
+                    {"privilege": "USAGE", "grantee_name": "FOO", "granted_to": "ROLE"},
+                    {
+                        "privilege": "USAGE",
+                        "grantee_name": "SOME_USER",
+                        "granted_to": "USER",
+                    },
+                ]
+            }
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert 'revoke usage on warehouse bar from user "SOME_USER"' in result
+    assert not any('from role "SOME_USER"' in s for s in result)
+
+
+def test_revoke_database_usage_from_user_grantee():
+    config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
+    state = {
+        "grants": {
+            "on_databases": {
+                "db1": [
+                    {"privilege": "USAGE", "grantee_name": "FOO", "granted_to": "ROLE"},
+                    {
+                        "privilege": "USAGE",
+                        "grantee_name": "ROGUE_USER",
+                        "granted_to": "USER",
+                    },
+                ]
+            },
+            "on_schemas": {"db1.sch1": []},
+            "future_in_schemas": {"db1.sch1": []},
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert 'revoke usage on database db1 from user "ROGUE_USER"' in result
+    assert not any('from role "ROGUE_USER"' in s for s in result)
+
+
+def test_revoke_schema_usage_from_user_grantee():
+    config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
+    state = {
+        "grants": {
+            "on_databases": {"db1": []},
+            "on_schemas": {
+                "db1.sch1": [
+                    {"privilege": "USAGE", "grantee_name": "FOO", "granted_to": "ROLE"},
+                    {
+                        "privilege": "USAGE",
+                        "grantee_name": "ROGUE_USER",
+                        "granted_to": "USER",
+                    },
+                ]
+            },
+            "future_in_schemas": {"db1.sch1": []},
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert 'revoke usage on schema db1.sch1 from user "ROGUE_USER"' in result
+    assert not any('from role "ROGUE_USER"' in s for s in result)
+
+
+def test_user_grantee_not_included_in_role_diff():
+    """User grantees should not interfere with role grant/revoke diffing."""
+    config = {"grants": [{"role": "foo", "warehouses": ["bar"]}]}
+    state = {
+        "grants": {
+            "on_warehouses": {
+                "bar": [
+                    {"privilege": "USAGE", "grantee_name": "FOO", "granted_to": "ROLE"},
+                    {
+                        "privilege": "USAGE",
+                        "grantee_name": "SOME_USER",
+                        "granted_to": "USER",
+                    },
+                ]
+            }
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    # foo should NOT be granted again (already exists as role grantee)
+    assert "grant usage on warehouse bar to role foo" not in result
+    # some_user should be revoked as user, not as role
+    assert 'revoke usage on warehouse bar from user "SOME_USER"' in result
+
+
+def test_unmanaged_privilege_revoked_with_correct_grantee_type():
+    """Unmanaged privileges should use correct grantee type from state."""
+    config = {"grants": [{"role": "foo", "warehouses": ["wh1"]}]}
+    state = {
+        "grants": {
+            "on_warehouses": {
+                "wh1": [
+                    {"privilege": "USAGE", "grantee_name": "FOO", "granted_to": "ROLE"},
+                    {
+                        "privilege": "OPERATE",
+                        "grantee_name": "SOME_USER",
+                        "granted_to": "USER",
+                    },
+                ]
+            },
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert 'revoke operate on warehouse wh1 from user "SOME_USER"' in result
+    assert not any('from role "SOME_USER"' in s for s in result)

--- a/tests/test_plan_overview.py
+++ b/tests/test_plan_overview.py
@@ -363,3 +363,19 @@ def test_revoke_users_overview():
     print(plan_overview)
     result = plan_overview.get("revoke_users")
     assert result == expected
+
+
+def test_revoke_other_overview():
+    plan = [
+        'revoke operate on warehouse wh1 from role "FOO"',
+        'revoke modify on database db1 from user "BAR"',
+        'revoke monitor on schema db1.sch1 from role "BAZ"',
+        'revoke usage on warehouse wh1 from role "OK"',
+    ]
+    plan_overview = overview(execution_plan=plan)
+    result = plan_overview.get("revoke_other")
+    assert len(result) == 3
+    assert 'revoke operate on warehouse wh1 from role "FOO"' in result
+    assert 'revoke modify on database db1 from user "BAR"' in result
+    assert 'revoke monitor on schema db1.sch1 from role "BAZ"' in result
+    assert 'revoke usage on warehouse wh1 from role "OK"' not in result

--- a/tests/test_plan_overview.py
+++ b/tests/test_plan_overview.py
@@ -321,6 +321,16 @@ def test_grant_create_overview():
     assert result == expected
 
 
+def test_grant_create_not_in_create_schemas():
+    plan = [
+        "grant create table on schema foo.bar to role baz",
+        "grant create view on schema foo.bar to role baz",
+    ]
+    plan_overview = overview(execution_plan=plan)
+    assert plan_overview.get("create_schemas") == []
+    assert len(plan_overview.get("grant_create")) == 2
+
+
 def test_grant_roles_overview():
     plan = [
         "grant role bar to role foo",


### PR DESCRIPTION
## Changes

- **fix(grants):** distinguish role vs user grantees in revoke SQL
- **refactor(grants):** replace hardcoded privilege checks with set-based diff
- **feat(overview):** add catch-all `revoke_other` category
- **fix(plan):** use `startswith` in overview to prevent category leaks (e.g. `grant create table on schema` no longer appears under `create_schemas`)
- **docs:** add ask-early-and-often guideline to copilot instructions