### PR TITLE
fix(grants): revoke stale future read grants on write-only schemas

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="snowbird",
-    version="0.6.1",
+    version="0.6.2",
     description=("Snowbird helps configure Snowflake resources for dataproducts"),
     # package_dir={"": "inbound"},
     packages=find_packages(include=("snowbird/*,")),

--- a/snowbird/plan.py
+++ b/snowbird/plan.py
@@ -574,7 +574,7 @@ def _grant_role_execution_plan(grants: list[dict], state: dict) -> list[str]:
                     )
                 )
 
-    # --- Future read grants (read_on_schemas) ---
+    # --- Future read grants ---
     future_in_schemas_state = state.get("future_in_schemas", {})
     future_grant_map = {
         "table": (grant_role_future_read_on_tables_in_schema, "tables"),
@@ -591,7 +591,14 @@ def _grant_role_execution_plan(grants: list[dict], state: dict) -> list[str]:
     # Track (schema_path, role) pairs that need new future grants — these also
     # need ALL grants to bootstrap existing objects in that schema.
     schemas_needing_bootstrap: set[tuple[str, str]] = set()
-    for schema_path, desired_roles in desired_future_read.items():
+    # Check all managed schemas that either have desired future reads or
+    # existing future grant state — ensures stale future grants are revoked
+    # even when a schema is only referenced via write_on_schemas or read_on_objects.
+    managed_future_schemas = set(desired_future_read.keys()) | (
+        set(future_in_schemas_state.keys()) & all_managed_schemas
+    )
+    for schema_path in managed_future_schemas:
+        desired_roles = desired_future_read.get(schema_path, set())
         database, schema = schema_path.split(".")
         future_schema_state = future_in_schemas_state.get(schema_path)
 

--- a/snowbird/state.py
+++ b/snowbird/state.py
@@ -89,8 +89,15 @@ def _get_future_schema_grants(
 ) -> dict:
     managed_schemas: set[str] = set()
     for grant in grants_config:
-        for schema_path in grant.get("read_on_schemas", []):
+        for schema_path in grant.get("read_on_schemas", []) + grant.get(
+            "write_on_schemas", []
+        ):
             managed_schemas.add(schema_path.lower())
+        for obj in grant.get("read_on_objects", []):
+            _, obj_path = obj.split(":", 1)
+            parts = obj_path.split(".")
+            if len(parts) >= 3:
+                managed_schemas.add(f"{parts[0]}.{parts[1]}".lower())
 
     future_grants: dict = {}
     for schema_path in managed_schemas:

--- a/tests/test_execution_plan.py
+++ b/tests/test_execution_plan.py
@@ -2266,6 +2266,186 @@ def test_future_grants_revokes_non_select_privileges():
     assert not any("READER" in s and "revoke" in s for s in result)
 
 
+def test_future_read_revoked_when_only_write_on_schemas():
+    """Future read grants must be revoked when schema is only in write_on_schemas."""
+    config = {"grants": [{"role": "writer", "write_on_schemas": ["db1.sch1"]}]}
+    state = {
+        "grants": {
+            "on_databases": {"db1": []},
+            "on_schemas": {"db1.sch1": []},
+            "future_in_schemas": {
+                "db1.sch1": [
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "TABLE",
+                        "grantee_name": "STALE_READER",
+                    },
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "VIEW",
+                        "grantee_name": "STALE_READER",
+                    },
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "DYNAMIC TABLE",
+                        "grantee_name": "STALE_READER",
+                    },
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "SEMANTIC VIEW",
+                        "grantee_name": "STALE_READER",
+                    },
+                ]
+            },
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert (
+        'revoke select on future tables in schema db1.sch1 from role "STALE_READER"'
+        in result
+    )
+    assert (
+        'revoke select on future views in schema db1.sch1 from role "STALE_READER"'
+        in result
+    )
+    assert (
+        'revoke select on future dynamic tables in schema db1.sch1 from role "STALE_READER"'
+        in result
+    )
+    assert (
+        'revoke select on future semantic views in schema db1.sch1 from role "STALE_READER"'
+        in result
+    )
+    # Also clean up existing objects
+    assert (
+        'revoke select on all tables in schema db1.sch1 from role "STALE_READER"'
+        in result
+    )
+    assert (
+        'revoke select on all views in schema db1.sch1 from role "STALE_READER"'
+        in result
+    )
+    assert (
+        'revoke select on all dynamic tables in schema db1.sch1 from role "STALE_READER"'
+        in result
+    )
+    assert (
+        'revoke select on all semantic views in schema db1.sch1 from role "STALE_READER"'
+        in result
+    )
+
+
+def test_future_read_revoked_when_only_read_on_objects():
+    """Future read grants must be revoked when schema is only in read_on_objects."""
+    config = {
+        "grants": [
+            {"role": "obj_reader", "read_on_objects": ["table:db1.sch1.t1"]}
+        ]
+    }
+    state = {
+        "grants": {
+            "on_databases": {"db1": []},
+            "on_schemas": {"db1.sch1": []},
+            "future_in_schemas": {
+                "db1.sch1": [
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "TABLE",
+                        "grantee_name": "STALE_READER",
+                    },
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "VIEW",
+                        "grantee_name": "STALE_READER",
+                    },
+                ]
+            },
+            "on_objects": {"table:db1.sch1.t1": []},
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert (
+        'revoke select on future tables in schema db1.sch1 from role "STALE_READER"'
+        in result
+    )
+    assert (
+        'revoke select on future views in schema db1.sch1 from role "STALE_READER"'
+        in result
+    )
+
+
+def test_future_read_no_regression_with_read_and_write():
+    """Schema in both read_on_schemas and write_on_schemas: future reads preserved."""
+    config = {
+        "grants": [
+            {"role": "reader", "read_on_schemas": ["db1.sch1"]},
+            {"role": "writer", "write_on_schemas": ["db1.sch1"]},
+        ]
+    }
+    state = {
+        "grants": {
+            "on_databases": {"db1": []},
+            "on_schemas": {"db1.sch1": []},
+            "future_in_schemas": {
+                "db1.sch1": [
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "TABLE",
+                        "grantee_name": "READER",
+                    },
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "VIEW",
+                        "grantee_name": "READER",
+                    },
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "DYNAMIC TABLE",
+                        "grantee_name": "READER",
+                    },
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "SEMANTIC VIEW",
+                        "grantee_name": "READER",
+                    },
+                ]
+            },
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    # reader's future grants should NOT be revoked
+    assert not any("revoke" in s and "reader" in s.lower() for s in result)
+    # writer should NOT get future read grants
+    assert not any(
+        "grant select on future" in s and "writer" in s for s in result
+    )
+
+
+def test_future_read_writer_role_revoked_on_write_only_schema():
+    """Writer role's stale future read grants revoked on write-only schema."""
+    config = {"grants": [{"role": "writer", "write_on_schemas": ["db1.sch1"]}]}
+    state = {
+        "grants": {
+            "on_databases": {"db1": []},
+            "on_schemas": {"db1.sch1": []},
+            "future_in_schemas": {
+                "db1.sch1": [
+                    {
+                        "privilege": "SELECT",
+                        "grant_on": "TABLE",
+                        "grantee_name": "WRITER",
+                    },
+                ]
+            },
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    # Even though writer is the configured role, write != future read
+    assert (
+        'revoke select on future tables in schema db1.sch1 from role "WRITER"' in result
+    )
+
+
 def test_future_grants_does_not_revoke_ownership():
     """Future grants diff must never revoke OWNERSHIP."""
     config = {


### PR DESCRIPTION
## Bug

Future read grants (SELECT on future tables/views/dynamic tables/semantic views) were not revoked when a schema was only referenced via `write_on_schemas` or `read_on_objects`.

## Root cause

1. **`state.py:_get_future_schema_grants`** — only fetched future grant state for schemas from `read_on_schemas`, ignoring `write_on_schemas` and `read_on_objects`
2. **`plan.py`** — future grants revocation loop only iterated `desired_future_read` (populated solely from `read_on_schemas`)

Other grant types (schema USAGE/CREATE, database, warehouse) were **not affected**.

## Fix

- **state.py**: Include `write_on_schemas` + `read_on_objects` in `_get_future_schema_grants`
- **plan.py**: Iterate `managed_future_schemas` (union of desired + all managed schemas with state) for future grants revocation
- **tests**: 4 new tests covering write-only, object-only, read+write regression, and writer-role stale grants
- **setup.py**: Bump version to 0.6.2