### PR TITLE
refactor: derive managed objects from spec declarations

### DIFF
--- a/snowbird/plan.py
+++ b/snowbird/plan.py
@@ -144,6 +144,10 @@ class UnmodifiableStateError(Exception):
     pass
 
 
+class UnmanagedReferenceError(Exception):
+    pass
+
+
 def load_config(path: str) -> dict:
     with open(path) as file:
         file_content = file.read().lower()
@@ -164,6 +168,44 @@ def _parse_object_type(type_input: str) -> tuple[str, str]:
         raise ValueError(
             f"Invalid input for object type, type must be one of {valid_types}, followed by a colon and a fully qualified object name (for example: table:my_database.my_schema.my_table)"
         )
+
+
+def _validate_grant_references(
+    grants: list[dict],
+    managed_warehouses: set[str],
+    managed_databases: set[str],
+    managed_schemas: set[str],
+    managed_roles: set[str],
+):
+    for grant in grants:
+        role = grant["role"].lower()
+        if role not in managed_roles:
+            raise UnmanagedReferenceError(
+                f"Grant references role '{grant['role']}' which is not declared in the 'roles' section"
+            )
+        for wh in grant.get("warehouses", []):
+            if wh.lower() not in managed_warehouses:
+                raise UnmanagedReferenceError(
+                    f"Grant references warehouse '{wh}' which is not declared in the 'warehouses' section"
+                )
+        for schema_path in grant.get("read_on_schemas", []) + grant.get(
+            "write_on_schemas", []
+        ):
+            if schema_path.lower() not in managed_schemas:
+                raise UnmanagedReferenceError(
+                    f"Grant references schema '{schema_path}' which is not declared in the 'databases' section"
+                )
+        for obj in grant.get("read_on_objects", []):
+            if ":" not in obj:
+                continue
+            _, obj_path = obj.split(":", 1)
+            parts = obj_path.split(".")
+            if len(parts) >= 2:
+                schema_key = f"{parts[0]}.{parts[1]}".lower()
+                if schema_key not in managed_schemas:
+                    raise UnmanagedReferenceError(
+                        f"Grant references object in schema '{schema_key}' which is not declared in the 'databases' section"
+                    )
 
 
 def _create_databases_execution_plan(databases: list[dict], state: dict) -> list[str]:
@@ -391,8 +433,19 @@ def _actual_grants(grant_state: list[dict]) -> set[tuple[str, str, str]]:
     }
 
 
-def _grant_role_execution_plan(grants: list[dict], state: dict) -> list[str]:
-    if len(grants) == 0:
+def _grant_role_execution_plan(
+    grants: list[dict],
+    state: dict,
+    managed_warehouses: set[str],
+    managed_databases: set[str],
+    managed_schemas: set[str],
+) -> list[str]:
+    if (
+        len(grants) == 0
+        and not managed_warehouses
+        and not managed_databases
+        and not managed_schemas
+    ):
         return []
     execution_plan = set()
 
@@ -449,7 +502,9 @@ def _grant_role_execution_plan(grants: list[dict], state: dict) -> list[str]:
 
     # --- Warehouse USAGE ---
     on_warehouses_state = state.get("on_warehouses", {})
-    for warehouse, desired_roles in desired_warehouse_roles.items():
+    all_warehouses_to_diff = managed_warehouses | set(desired_warehouse_roles.keys())
+    for warehouse in all_warehouses_to_diff:
+        desired_roles = desired_warehouse_roles.get(warehouse, set())
         warehouse_grant_state = on_warehouses_state.get(warehouse)
         desired = {("usage", "role", r) for r in desired_roles}
         if warehouse_grant_state is None:
@@ -478,7 +533,9 @@ def _grant_role_execution_plan(grants: list[dict], state: dict) -> list[str]:
 
     # --- Database USAGE ---
     on_databases_state = state.get("on_databases", {})
-    for database, desired_roles in desired_database_roles.items():
+    all_databases_to_diff = managed_databases | set(desired_database_roles.keys())
+    for database in all_databases_to_diff:
+        desired_roles = desired_database_roles.get(database, set())
         db_grant_state = on_databases_state.get(database)
         desired = {("usage", "role", r) for r in desired_roles}
         if db_grant_state is None:
@@ -518,7 +575,9 @@ def _grant_role_execution_plan(grants: list[dict], state: dict) -> list[str]:
         "row access policy",
         "procedure",
     ]
-    all_managed_schemas = set(desired_schema_roles.keys()) | set(desired_create.keys())
+    all_managed_schemas = (
+        set(desired_schema_roles.keys()) | set(desired_create.keys()) | managed_schemas
+    )
     for schema_path in all_managed_schemas:
         database, schema = schema_path.split(".")
         schema_grant_state = on_schemas_state.get(schema_path)
@@ -991,6 +1050,29 @@ def execution_plan(config: dict, state={}) -> list[str]:
     roles = config.get("roles", [])
     grants = config.get("grants", [])
     network_policies = config.get("network_policies", [])
+
+    managed_warehouse_names = {wh["name"].lower() for wh in warehouses}
+    managed_database_names = {db["name"].lower() for db in databases}
+    managed_schema_names: set[str] = set()
+    for db in databases:
+        for schema in db.get("schemas", []):
+            managed_schema_names.add(f"{db['name'].lower()}.{schema['name'].lower()}")
+    managed_role_names = {r["name"].lower() for r in roles}
+
+    _validate_grant_references(
+        grants,
+        managed_warehouse_names,
+        managed_database_names,
+        managed_schema_names,
+        managed_role_names,
+    )
+
+    # Add synthetic grant entries for managed roles without explicit grants
+    grant_role_names = {g["role"].lower() for g in grants}
+    for role in roles:
+        if role["name"].lower() not in grant_role_names:
+            grants.append({"role": role["name"]})
+
     _append_grant_roles_to_sysadmin(grants=grants)
 
     databases_state = _database_state(databases, state)
@@ -1025,7 +1107,15 @@ def execution_plan(config: dict, state={}) -> list[str]:
     plan.extend(_create_users_execution_plan(users=users, state=users_state))
     plan.extend(_create_roles_execution_plan(roles=roles, state=roles_state))
 
-    plan.extend(_grant_role_execution_plan(grants=grants, state=grants_state))
+    plan.extend(
+        _grant_role_execution_plan(
+            grants=grants,
+            state=grants_state,
+            managed_warehouses=managed_warehouse_names,
+            managed_databases=managed_database_names,
+            managed_schemas=managed_schema_names,
+        )
+    )
     if len(plan) > plan_len:
         plan.insert(plan_len, use_useradmin)
 
@@ -1034,15 +1124,23 @@ def execution_plan(config: dict, state={}) -> list[str]:
 
 
 def overview(execution_plan: dict) -> dict:
-    create_databases = [s.split()[5] for s in execution_plan if s.startswith("create database")]
+    create_databases = [
+        s.split()[5] for s in execution_plan if s.startswith("create database")
+    ]
     create_transient_databases = [
-        s.split()[6] for s in execution_plan if s.startswith("create transient database")
+        s.split()[6]
+        for s in execution_plan
+        if s.startswith("create transient database")
     ]
     create_databases.extend(create_transient_databases)
-    alter_databases = [s.split()[2] for s in execution_plan if s.startswith("alter database")]
+    alter_databases = [
+        s.split()[2] for s in execution_plan if s.startswith("alter database")
+    ]
     modify_databases = [d for d in alter_databases if d not in create_databases]
 
-    create_schemas = [s.split()[5] for s in execution_plan if s.startswith("create schema")]
+    create_schemas = [
+        s.split()[5] for s in execution_plan if s.startswith("create schema")
+    ]
     create_transient_schemas = [
         s.split()[6] for s in execution_plan if s.startswith("create transient schema")
     ]
@@ -1063,7 +1161,9 @@ def overview(execution_plan: dict) -> dict:
     create_warehouses = [
         s.split()[5] for s in execution_plan if s.startswith("create warehouse")
     ]
-    alter_warehouses = [s.split()[2] for s in execution_plan if s.startswith("alter warehouse")]
+    alter_warehouses = [
+        s.split()[2] for s in execution_plan if s.startswith("alter warehouse")
+    ]
     modify_warehouses = [w for w in alter_warehouses if w not in create_warehouses]
 
     create_network_policies = [

--- a/snowbird/state.py
+++ b/snowbird/state.py
@@ -19,12 +19,9 @@ def _get_role_grants(roles: list[dict], cursor: SnowflakeCursor) -> dict:
 
 
 def _get_warehouse_grants(
-    grants_config: list[dict], cursor: SnowflakeCursor
+    warehouses_config: list[dict], cursor: SnowflakeCursor
 ) -> dict:
-    managed_warehouses: set[str] = set()
-    for grant in grants_config:
-        for wh in grant.get("warehouses", []):
-            managed_warehouses.add(wh.lower())
+    managed_warehouses: set[str] = {wh["name"].lower() for wh in warehouses_config}
 
     warehouse_grants: dict = {}
     for warehouse in managed_warehouses:
@@ -36,18 +33,8 @@ def _get_warehouse_grants(
     return warehouse_grants
 
 
-def _get_database_grants(
-    grants_config: list[dict], cursor: SnowflakeCursor
-) -> dict:
-    managed_databases: set[str] = set()
-    for grant in grants_config:
-        for schema_path in grant.get("read_on_schemas", []) + grant.get(
-            "write_on_schemas", []
-        ):
-            managed_databases.add(schema_path.split(".")[0].lower())
-        for obj in grant.get("read_on_objects", []):
-            _, obj_path = obj.split(":", 1)
-            managed_databases.add(obj_path.split(".")[0].lower())
+def _get_database_grants(databases_config: list[dict], cursor: SnowflakeCursor) -> dict:
+    managed_databases: set[str] = {db["name"].lower() for db in databases_config}
 
     database_grants: dict = {}
     for database in managed_databases:
@@ -59,20 +46,12 @@ def _get_database_grants(
     return database_grants
 
 
-def _get_schema_grants(
-    grants_config: list[dict], cursor: SnowflakeCursor
-) -> dict:
+def _get_schema_grants(databases_config: list[dict], cursor: SnowflakeCursor) -> dict:
     managed_schemas: set[str] = set()
-    for grant in grants_config:
-        for schema_path in grant.get("read_on_schemas", []) + grant.get(
-            "write_on_schemas", []
-        ):
-            managed_schemas.add(schema_path.lower())
-        for obj in grant.get("read_on_objects", []):
-            _, obj_path = obj.split(":", 1)
-            parts = obj_path.split(".")
-            if len(parts) >= 3:
-                managed_schemas.add(f"{parts[0]}.{parts[1]}".lower())
+    for db in databases_config:
+        db_name = db["name"].lower()
+        for schema in db.get("schemas", []):
+            managed_schemas.add(f"{db_name}.{schema['name'].lower()}")
 
     schema_grants: dict = {}
     for schema_path in managed_schemas:
@@ -85,19 +64,13 @@ def _get_schema_grants(
 
 
 def _get_future_schema_grants(
-    grants_config: list[dict], cursor: SnowflakeCursor
+    databases_config: list[dict], cursor: SnowflakeCursor
 ) -> dict:
     managed_schemas: set[str] = set()
-    for grant in grants_config:
-        for schema_path in grant.get("read_on_schemas", []) + grant.get(
-            "write_on_schemas", []
-        ):
-            managed_schemas.add(schema_path.lower())
-        for obj in grant.get("read_on_objects", []):
-            _, obj_path = obj.split(":", 1)
-            parts = obj_path.split(".")
-            if len(parts) >= 3:
-                managed_schemas.add(f"{parts[0]}.{parts[1]}".lower())
+    for db in databases_config:
+        db_name = db["name"].lower()
+        for schema in db.get("schemas", []):
+            managed_schemas.add(f"{db_name}.{schema['name'].lower()}")
 
     future_grants: dict = {}
     for schema_path in managed_schemas:
@@ -117,9 +90,7 @@ _OBJECT_TYPE_MAP = {
 }
 
 
-def _get_object_grants(
-    grants_config: list[dict], cursor: SnowflakeCursor
-) -> dict:
+def _get_object_grants(grants_config: list[dict], cursor: SnowflakeCursor) -> dict:
     managed_objects: list[tuple[str, str, str]] = []
     for grant in grants_config:
         for obj in grant.get("read_on_objects", []):
@@ -201,6 +172,8 @@ def current_state(config: dict) -> dict:
     roles_config = config.get("roles", [])
     users_config = config.get("users", [])
     network_policies_config = config.get("network_policies", [])
+    databases_config = config.get("databases", [])
+    warehouses_config = config.get("warehouses", [])
     grants_config = config.get("grants", [])
 
     with snowflake_cursor() as cursor:
@@ -210,10 +183,10 @@ def current_state(config: dict) -> dict:
         users = _get_users_state(users_config, cursor)
         roles = cursor.execute("show roles").fetchall()
         grants_of_roles = _get_role_grants(roles_config, cursor)
-        warehouse_grants = _get_warehouse_grants(grants_config, cursor)
-        database_grants = _get_database_grants(grants_config, cursor)
-        schema_grants = _get_schema_grants(grants_config, cursor)
-        future_schema_grants = _get_future_schema_grants(grants_config, cursor)
+        warehouse_grants = _get_warehouse_grants(warehouses_config, cursor)
+        database_grants = _get_database_grants(databases_config, cursor)
+        schema_grants = _get_schema_grants(databases_config, cursor)
+        future_schema_grants = _get_future_schema_grants(databases_config, cursor)
         object_grants = _get_object_grants(grants_config, cursor)
         network_policies = _get_network_policies(network_policies_config, cursor)
     return {

--- a/tests/test_execution_plan.py
+++ b/tests/test_execution_plan.py
@@ -1,6 +1,10 @@
 import pytest
 
-from snowbird.plan import UnmodifiableStateError, execution_plan
+from snowbird.plan import (
+    UnmanagedReferenceError,
+    UnmodifiableStateError,
+    execution_plan,
+)
 
 
 def test_create_database():
@@ -478,6 +482,7 @@ def test_create_role():
     expected = [
         "use role useradmin",
         "create role if not exists foo",
+        'grant role foo to role "SYSADMIN"',
     ]
     result = execution_plan(config)
     print(result)
@@ -645,11 +650,19 @@ def test_modifying_network_policy_blocked_network_rules():
 
 
 def test_grant_role_warehouse():
-    config = {"grants": [{"role": "foo", "warehouses": ["bar"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "warehouses": [{"name": "bar"}],
+        "grants": [{"role": "foo", "warehouses": ["bar"]}],
+    }
     expected = {
-        "use role useradmin",
-        "grant usage on warehouse bar to role foo",
+        "alter warehouse bar set warehouse_size = 'x-small'",
+        "create role if not exists foo",
+        "create warehouse if not exists bar with warehouse_size = 'x-small' auto_suspend = 30 initially_suspended = true",
         'grant role foo to role "SYSADMIN"',
+        "grant usage on warehouse bar to role foo",
+        "use role sysadmin",
+        "use role useradmin",
     }
     result = set(execution_plan(config))
     print(result)
@@ -657,12 +670,22 @@ def test_grant_role_warehouse():
 
 
 def test_grant_role_multiple_warehouses():
-    config = {"grants": [{"role": "foo", "warehouses": ["bar", "baz"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "warehouses": [{"name": "bar"}, {"name": "baz"}],
+        "grants": [{"role": "foo", "warehouses": ["bar", "baz"]}],
+    }
     expected = {
-        "use role useradmin",
+        "alter warehouse bar set warehouse_size = 'x-small'",
+        "alter warehouse baz set warehouse_size = 'x-small'",
+        "create role if not exists foo",
+        "create warehouse if not exists bar with warehouse_size = 'x-small' auto_suspend = 30 initially_suspended = true",
+        "create warehouse if not exists baz with warehouse_size = 'x-small' auto_suspend = 30 initially_suspended = true",
+        'grant role foo to role "SYSADMIN"',
         "grant usage on warehouse bar to role foo",
         "grant usage on warehouse baz to role foo",
-        'grant role foo to role "SYSADMIN"',
+        "use role sysadmin",
+        "use role useradmin",
     }
     result = set(execution_plan(config))
     print(result)
@@ -670,21 +693,31 @@ def test_grant_role_multiple_warehouses():
 
 
 def test_grant_role_write_on_schema():
-    config = {"grants": [{"role": "foo", "write_on_schemas": ["bar.baz"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "databases": [{"name": "bar", "schemas": [{"name": "baz"}]}],
+        "grants": [{"role": "foo", "write_on_schemas": ["bar.baz"]}],
+    }
     expected = {
-        'grant role foo to role "SYSADMIN"',
-        "grant create dynamic table on schema bar.baz to role foo",
-        "grant create row access policy on schema bar.baz to role foo",
+        "alter database bar set data_retention_time_in_days = 7",
+        "alter schema bar.baz set data_retention_time_in_days = 7",
+        "create database if not exists bar",
+        "create role if not exists foo",
+        "create schema if not exists bar.baz",
         "grant create alert on schema bar.baz to role foo",
-        "grant create table on schema bar.baz to role foo",
-        "grant create procedure on schema bar.baz to role foo",
+        "grant create dynamic table on schema bar.baz to role foo",
         "grant create masking policy on schema bar.baz to role foo",
-        "use role useradmin",
-        "grant usage on database bar to role foo",
-        "grant usage on schema bar.baz to role foo",
+        "grant create procedure on schema bar.baz to role foo",
+        "grant create row access policy on schema bar.baz to role foo",
+        "grant create semantic view on schema bar.baz to role foo",
+        "grant create table on schema bar.baz to role foo",
         "grant create task on schema bar.baz to role foo",
         "grant create view on schema bar.baz to role foo",
-        "grant create semantic view on schema bar.baz to role foo",
+        'grant role foo to role "SYSADMIN"',
+        "grant usage on database bar to role foo",
+        "grant usage on schema bar.baz to role foo",
+        "use role sysadmin",
+        "use role useradmin",
     }
     result = set(execution_plan(config))
     print(result)
@@ -692,31 +725,43 @@ def test_grant_role_write_on_schema():
 
 
 def test_grant_role_write_on_multiple_schemas():
-    config = {"grants": [{"role": "foo", "write_on_schemas": ["bar.baz", "bar.qux"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "databases": [{"name": "bar", "schemas": [{"name": "baz"}, {"name": "qux"}]}],
+        "grants": [{"role": "foo", "write_on_schemas": ["bar.baz", "bar.qux"]}],
+    }
     expected = {
-        "grant create row access policy on schema bar.baz to role foo",
+        "alter database bar set data_retention_time_in_days = 7",
+        "alter schema bar.baz set data_retention_time_in_days = 7",
+        "alter schema bar.qux set data_retention_time_in_days = 7",
+        "create database if not exists bar",
+        "create role if not exists foo",
+        "create schema if not exists bar.baz",
+        "create schema if not exists bar.qux",
+        "grant create alert on schema bar.baz to role foo",
+        "grant create alert on schema bar.qux to role foo",
+        "grant create dynamic table on schema bar.baz to role foo",
+        "grant create dynamic table on schema bar.qux to role foo",
+        "grant create masking policy on schema bar.baz to role foo",
+        "grant create masking policy on schema bar.qux to role foo",
+        "grant create procedure on schema bar.baz to role foo",
         "grant create procedure on schema bar.qux to role foo",
-        "grant create table on schema bar.baz to role foo",
-        "grant create table on schema bar.qux to role foo",
+        "grant create row access policy on schema bar.baz to role foo",
+        "grant create row access policy on schema bar.qux to role foo",
         "grant create semantic view on schema bar.baz to role foo",
         "grant create semantic view on schema bar.qux to role foo",
-        "grant usage on schema bar.qux to role foo",
-        "grant create row access policy on schema bar.qux to role foo",
-        "grant create alert on schema bar.qux to role foo",
-        "grant create dynamic table on schema bar.qux to role foo",
-        "grant create view on schema bar.qux to role foo",
-        "grant create masking policy on schema bar.qux to role foo",
-        "grant create view on schema bar.baz to role foo",
-        "grant usage on database bar to role foo",
-        "use role useradmin",
-        "grant usage on schema bar.baz to role foo",
+        "grant create table on schema bar.baz to role foo",
+        "grant create table on schema bar.qux to role foo",
         "grant create task on schema bar.baz to role foo",
-        'grant role foo to role "SYSADMIN"',
-        "grant create dynamic table on schema bar.baz to role foo",
-        "grant create alert on schema bar.baz to role foo",
-        "grant create masking policy on schema bar.baz to role foo",
-        "grant create procedure on schema bar.baz to role foo",
         "grant create task on schema bar.qux to role foo",
+        "grant create view on schema bar.baz to role foo",
+        "grant create view on schema bar.qux to role foo",
+        'grant role foo to role "SYSADMIN"',
+        "grant usage on database bar to role foo",
+        "grant usage on schema bar.baz to role foo",
+        "grant usage on schema bar.qux to role foo",
+        "use role sysadmin",
+        "use role useradmin",
     }
     result = set(execution_plan(config))
     print(result)
@@ -724,20 +769,30 @@ def test_grant_role_write_on_multiple_schemas():
 
 
 def test_grant_role_read_on_schema():
-    config = {"grants": [{"role": "foo", "read_on_schemas": ["bar.baz"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "databases": [{"name": "bar", "schemas": [{"name": "baz"}]}],
+        "grants": [{"role": "foo", "read_on_schemas": ["bar.baz"]}],
+    }
     expected = {
-        "use role useradmin",
-        "grant usage on database bar to role foo",
-        "grant usage on schema bar.baz to role foo",
-        "grant select on all tables in schema bar.baz to role foo",
-        "grant select on future tables in schema bar.baz to role foo",
-        "grant select on all views in schema bar.baz to role foo",
-        "grant select on future views in schema bar.baz to role foo",
+        "alter database bar set data_retention_time_in_days = 7",
+        "alter schema bar.baz set data_retention_time_in_days = 7",
+        "create database if not exists bar",
+        "create role if not exists foo",
+        "create schema if not exists bar.baz",
         'grant role foo to role "SYSADMIN"',
         "grant select on all dynamic tables in schema bar.baz to role foo",
-        "grant select on future dynamic tables in schema bar.baz to role foo",
         "grant select on all semantic views in schema bar.baz to role foo",
+        "grant select on all tables in schema bar.baz to role foo",
+        "grant select on all views in schema bar.baz to role foo",
+        "grant select on future dynamic tables in schema bar.baz to role foo",
         "grant select on future semantic views in schema bar.baz to role foo",
+        "grant select on future tables in schema bar.baz to role foo",
+        "grant select on future views in schema bar.baz to role foo",
+        "grant usage on database bar to role foo",
+        "grant usage on schema bar.baz to role foo",
+        "use role sysadmin",
+        "use role useradmin",
     }
     result = set(execution_plan(config))
     print(result)
@@ -745,30 +800,41 @@ def test_grant_role_read_on_schema():
 
 
 def test_grant_role_read_on_multiple_schemas():
-    config = {"grants": [{"role": "foo", "read_on_schemas": ["bar.baz", "bar.qux"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "databases": [{"name": "bar", "schemas": [{"name": "baz"}, {"name": "qux"}]}],
+        "grants": [{"role": "foo", "read_on_schemas": ["bar.baz", "bar.qux"]}],
+    }
     expected = {
-        "use role useradmin",
-        "grant usage on database bar to role foo",
-        "grant usage on schema bar.baz to role foo",
-        "grant select on all tables in schema bar.baz to role foo",
-        "grant select on future tables in schema bar.baz to role foo",
-        "grant select on all views in schema bar.baz to role foo",
-        "grant select on future views in schema bar.baz to role foo",
-        "grant usage on database bar to role foo",
-        "grant usage on schema bar.qux to role foo",
-        "grant select on all tables in schema bar.qux to role foo",
-        "grant select on future tables in schema bar.qux to role foo",
-        "grant select on all views in schema bar.qux to role foo",
-        "grant select on future views in schema bar.qux to role foo",
+        "alter database bar set data_retention_time_in_days = 7",
+        "alter schema bar.baz set data_retention_time_in_days = 7",
+        "alter schema bar.qux set data_retention_time_in_days = 7",
+        "create database if not exists bar",
+        "create role if not exists foo",
+        "create schema if not exists bar.baz",
+        "create schema if not exists bar.qux",
         'grant role foo to role "SYSADMIN"',
         "grant select on all dynamic tables in schema bar.baz to role foo",
-        "grant select on future dynamic tables in schema bar.baz to role foo",
         "grant select on all dynamic tables in schema bar.qux to role foo",
-        "grant select on future dynamic tables in schema bar.qux to role foo",
         "grant select on all semantic views in schema bar.baz to role foo",
-        "grant select on future semantic views in schema bar.baz to role foo",
         "grant select on all semantic views in schema bar.qux to role foo",
+        "grant select on all tables in schema bar.baz to role foo",
+        "grant select on all tables in schema bar.qux to role foo",
+        "grant select on all views in schema bar.baz to role foo",
+        "grant select on all views in schema bar.qux to role foo",
+        "grant select on future dynamic tables in schema bar.baz to role foo",
+        "grant select on future dynamic tables in schema bar.qux to role foo",
+        "grant select on future semantic views in schema bar.baz to role foo",
         "grant select on future semantic views in schema bar.qux to role foo",
+        "grant select on future tables in schema bar.baz to role foo",
+        "grant select on future tables in schema bar.qux to role foo",
+        "grant select on future views in schema bar.baz to role foo",
+        "grant select on future views in schema bar.qux to role foo",
+        "grant usage on database bar to role foo",
+        "grant usage on schema bar.baz to role foo",
+        "grant usage on schema bar.qux to role foo",
+        "use role sysadmin",
+        "use role useradmin",
     }
     result = set(execution_plan(config))
     print(result)
@@ -777,15 +843,14 @@ def test_grant_role_read_on_multiple_schemas():
 
 def test_grant_role_read_on_objects():
     config = {
+        "roles": [{"name": "foo"}],
+        "databases": [{"name": "bar", "schemas": [{"name": "baz"}]}],
         "grants": [
             {
                 "role": "foo",
-                "read_on_objects": [
-                    "table:bar.baz.my_table",
-                    "view:bar.baz.my_view",
-                ],
+                "read_on_objects": ["table:bar.baz.my_table", "view:bar.baz.my_view"],
             }
-        ]
+        ],
     }
     result = set(execution_plan(config))
     # Should grant usage on parent db and schema
@@ -801,6 +866,8 @@ def test_grant_role_read_on_objects():
 
 def test_grant_role_read_on_objects_all_types():
     config = {
+        "roles": [{"name": "foo"}],
+        "databases": [{"name": "db", "schemas": [{"name": "sch"}]}],
         "grants": [
             {
                 "role": "foo",
@@ -811,7 +878,7 @@ def test_grant_role_read_on_objects_all_types():
                     "semantic_view:db.sch.sv1",
                 ],
             }
-        ]
+        ],
     }
     result = set(execution_plan(config))
     assert "grant select on table db.sch.t1 to role foo" in result
@@ -822,12 +889,9 @@ def test_grant_role_read_on_objects_all_types():
 
 def test_read_on_objects_invalid_type_prefix_raises_error():
     config = {
-        "grants": [
-            {
-                "role": "foo",
-                "read_on_objects": ["invalid_type:db.sch.obj"],
-            }
-        ]
+        "roles": [{"name": "foo"}],
+        "databases": [{"name": "db", "schemas": [{"name": "sch"}]}],
+        "grants": [{"role": "foo", "read_on_objects": ["invalid_type:db.sch.obj"]}],
     }
     with pytest.raises(ValueError, match="Invalid input for object type"):
         execution_plan(config)
@@ -835,12 +899,8 @@ def test_read_on_objects_invalid_type_prefix_raises_error():
 
 def test_read_on_objects_missing_type_prefix_raises_error():
     config = {
-        "grants": [
-            {
-                "role": "foo",
-                "read_on_objects": ["db.sch.obj"],
-            }
-        ]
+        "roles": [{"name": "foo"}],
+        "grants": [{"role": "foo", "read_on_objects": ["db.sch.obj"]}],
     }
     with pytest.raises(
         ValueError,
@@ -851,12 +911,9 @@ def test_read_on_objects_missing_type_prefix_raises_error():
 
 def test_read_on_objects_invalid_path_raises_error():
     config = {
-        "grants": [
-            {
-                "role": "foo",
-                "read_on_objects": ["table:db.obj"],
-            }
-        ]
+        "roles": [{"name": "foo"}],
+        "databases": [{"name": "db", "schemas": [{"name": "obj"}]}],
+        "grants": [{"role": "foo", "read_on_objects": ["table:db.obj"]}],
     }
     with pytest.raises(
         ValueError,
@@ -865,12 +922,92 @@ def test_read_on_objects_invalid_path_raises_error():
         execution_plan(config)
 
 
+def test_grant_referencing_unmanaged_role_raises_error():
+    config = {
+        "warehouses": [{"name": "bar"}],
+        "grants": [{"role": "foo", "warehouses": ["bar"]}],
+    }
+    with pytest.raises(UnmanagedReferenceError, match="role 'foo'.*not declared"):
+        execution_plan(config)
+
+
+def test_grant_referencing_unmanaged_warehouse_raises_error():
+    config = {
+        "roles": [{"name": "foo"}],
+        "grants": [{"role": "foo", "warehouses": ["bar"]}],
+    }
+    with pytest.raises(UnmanagedReferenceError, match="warehouse 'bar'.*not declared"):
+        execution_plan(config)
+
+
+def test_grant_referencing_unmanaged_schema_raises_error():
+    config = {
+        "roles": [{"name": "foo"}],
+        "grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}],
+    }
+    with pytest.raises(
+        UnmanagedReferenceError, match="schema 'db1.sch1'.*not declared"
+    ):
+        execution_plan(config)
+
+
+def test_managed_role_with_no_grants_gets_sysadmin():
+    config = {
+        "roles": [{"name": "orphan_role"}],
+    }
+    result = set(execution_plan(config))
+    assert 'grant role orphan_role to role "SYSADMIN"' in result
+
+
+def test_managed_role_with_no_grants_revokes_stale_assignments():
+    config = {
+        "roles": [{"name": "orphan_role"}],
+    }
+    state = {
+        "roles": [{"name": "orphan_role", "owner": "USERADMIN"}],
+        "grants": {
+            "of_roles": {
+                "orphan_role": [
+                    {"grantee_name": "STALE_ROLE", "granted_to": "ROLE"},
+                    {"grantee_name": "SYSADMIN", "granted_to": "ROLE"},
+                ]
+            }
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert 'revoke role orphan_role from role "STALE_ROLE"' in result
+    assert 'revoke role orphan_role from role "SYSADMIN"' not in result
+
+
+def test_managed_warehouse_with_no_grants_revokes_stale():
+    config = {
+        "warehouses": [{"name": "wh1"}],
+    }
+    state = {
+        "grants": {
+            "on_warehouses": {
+                "wh1": [
+                    {"privilege": "USAGE", "grantee_name": "STALE_ROLE"},
+                    {"privilege": "OWNERSHIP", "grantee_name": "SYSADMIN"},
+                ]
+            }
+        },
+    }
+    result = set(execution_plan(config=config, state=state))
+    assert 'revoke usage on warehouse wh1 from role "STALE_ROLE"' in result
+    assert not any("revoke ownership" in s for s in result)
+
+
 def test_grant_role_to_role():
-    config = {"grants": [{"role": "foo", "to_roles": ["bar"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "grants": [{"role": "foo", "to_roles": ["bar"]}],
+    }
     expected = {
-        "use role useradmin",
+        "create role if not exists foo",
         'grant role foo to role "BAR"',
         'grant role foo to role "SYSADMIN"',
+        "use role useradmin",
     }
     result = set(execution_plan(config))
     print(result)
@@ -878,12 +1015,16 @@ def test_grant_role_to_role():
 
 
 def test_grant_role_to_multiple_roles():
-    config = {"grants": [{"role": "foo", "to_roles": ["bar", "baz"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "grants": [{"role": "foo", "to_roles": ["bar", "baz"]}],
+    }
     expected = {
-        "use role useradmin",
+        "create role if not exists foo",
         'grant role foo to role "BAR"',
         'grant role foo to role "BAZ"',
         'grant role foo to role "SYSADMIN"',
+        "use role useradmin",
     }
     result = set(execution_plan(config))
     print(result)
@@ -891,11 +1032,15 @@ def test_grant_role_to_multiple_roles():
 
 
 def test_grant_role_to_user():
-    config = {"grants": [{"role": "foo", "to_users": ["bar"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "grants": [{"role": "foo", "to_users": ["bar"]}],
+    }
     expected = {
-        "use role useradmin",
+        "create role if not exists foo",
         'grant role foo to role "SYSADMIN"',
         'grant role foo to user "BAR"',
+        "use role useradmin",
     }
     result = set(execution_plan(config))
     print(result)
@@ -903,12 +1048,16 @@ def test_grant_role_to_user():
 
 
 def test_grant_role_to_multiple_users():
-    config = {"grants": [{"role": "foo", "to_users": ["bar", "baz"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "grants": [{"role": "foo", "to_users": ["bar", "baz"]}],
+    }
     expected = {
-        "use role useradmin",
+        "create role if not exists foo",
         'grant role foo to role "SYSADMIN"',
         'grant role foo to user "BAR"',
         'grant role foo to user "BAZ"',
+        "use role useradmin",
     }
     result = set(execution_plan(config))
     print(result)
@@ -916,9 +1065,7 @@ def test_grant_role_to_multiple_users():
 
 
 def test_revoke_role_from_user():
-    config = {
-        "grants": [{"role": "foo"}],
-    }
+    config = {"roles": [{"name": "foo"}], "grants": [{"role": "foo"}]}
     state = {
         "grants": {
             "of_roles": {
@@ -932,9 +1079,10 @@ def test_revoke_role_from_user():
         },
     }
     expected = {
-        "use role useradmin",
-        'revoke role foo from user "BAR"',
+        "create role if not exists foo",
         'grant role foo to role "SYSADMIN"',
+        'revoke role foo from user "BAR"',
+        "use role useradmin",
     }
     result = set(execution_plan(config=config, state=state))
     print(result)
@@ -942,9 +1090,7 @@ def test_revoke_role_from_user():
 
 
 def test_revoke_role_from_role():
-    config = {
-        "grants": [{"role": "foo"}],
-    }
+    config = {"roles": [{"name": "foo"}], "grants": [{"role": "foo"}]}
     state = {
         "grants": {
             "of_roles": {
@@ -958,9 +1104,10 @@ def test_revoke_role_from_role():
         },
     }
     expected = {
-        "use role useradmin",
+        "create role if not exists foo",
         'grant role foo to role "SYSADMIN"',
         'revoke role foo from role "BAR"',
+        "use role useradmin",
     }
     result = set(execution_plan(config=config, state=state))
     print(result)
@@ -968,9 +1115,7 @@ def test_revoke_role_from_role():
 
 
 def test_not_revoking_role_from_sysadmin_when_not_explicily_defined():
-    config = {
-        "grants": [{"role": "foo"}],
-    }
+    config = {"roles": [{"name": "foo"}], "grants": [{"role": "foo"}]}
     state = {
         "grants": {
             "of_roles": {
@@ -983,7 +1128,7 @@ def test_not_revoking_role_from_sysadmin_when_not_explicily_defined():
             }
         },
     }
-    expected = []
+    expected = ["use role useradmin", "create role if not exists foo"]
     result = execution_plan(config=config, state=state)
     print(result)
     assert result == expected
@@ -991,9 +1136,14 @@ def test_not_revoking_role_from_sysadmin_when_not_explicily_defined():
 
 def test_explicit_granting_role_to_sysadmin_should_only_yield_one_grant_statement():
     config = {
+        "roles": [{"name": "foo"}],
         "grants": [{"role": "foo", "to_roles": ["sysadmin"]}],
     }
-    expected = ["use role useradmin", 'grant role foo to role "SYSADMIN"']
+    expected = [
+        "use role useradmin",
+        "create role if not exists foo",
+        'grant role foo to role "SYSADMIN"',
+    ]
     result = execution_plan(config=config)
     print(result)
     assert result == expected
@@ -1012,6 +1162,7 @@ def test_switching_executer_role():
         "alter schema foo.bar set data_retention_time_in_days = 7",
         "use role useradmin",
         "create role if not exists baz",
+        'grant role baz to role "SYSADMIN"',
     ]
     result = execution_plan(config)
     print(result)
@@ -1019,7 +1170,11 @@ def test_switching_executer_role():
 
 
 def test_grant_warehouse_skipped_when_already_exists():
-    config = {"grants": [{"role": "foo", "warehouses": ["bar"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "warehouses": [{"name": "bar"}],
+        "grants": [{"role": "foo", "warehouses": ["bar"]}],
+    }
     state = {
         "grants": {
             "on_warehouses": {
@@ -1030,8 +1185,12 @@ def test_grant_warehouse_skipped_when_already_exists():
         },
     }
     expected = {
-        "use role useradmin",
+        "alter warehouse bar set warehouse_size = 'x-small'",
+        "create role if not exists foo",
+        "create warehouse if not exists bar with warehouse_size = 'x-small' auto_suspend = 30 initially_suspended = true",
         'grant role foo to role "SYSADMIN"',
+        "use role sysadmin",
+        "use role useradmin",
     }
     result = set(execution_plan(config=config, state=state))
     print(result)
@@ -1039,14 +1198,22 @@ def test_grant_warehouse_skipped_when_already_exists():
 
 
 def test_grant_warehouse_when_not_in_state():
-    config = {"grants": [{"role": "foo", "warehouses": ["bar"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "warehouses": [{"name": "bar"}],
+        "grants": [{"role": "foo", "warehouses": ["bar"]}],
+    }
     state = {
         "grants": {"on_warehouses": {"bar": []}},
     }
     expected = {
-        "use role useradmin",
-        "grant usage on warehouse bar to role foo",
+        "alter warehouse bar set warehouse_size = 'x-small'",
+        "create role if not exists foo",
+        "create warehouse if not exists bar with warehouse_size = 'x-small' auto_suspend = 30 initially_suspended = true",
         'grant role foo to role "SYSADMIN"',
+        "grant usage on warehouse bar to role foo",
+        "use role sysadmin",
+        "use role useradmin",
     }
     result = set(execution_plan(config=config, state=state))
     print(result)
@@ -1054,7 +1221,11 @@ def test_grant_warehouse_when_not_in_state():
 
 
 def test_revoke_warehouse_from_unlisted_role():
-    config = {"grants": [{"role": "foo", "warehouses": ["bar"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "warehouses": [{"name": "bar"}],
+        "grants": [{"role": "foo", "warehouses": ["bar"]}],
+    }
     state = {
         "grants": {
             "on_warehouses": {
@@ -1066,9 +1237,13 @@ def test_revoke_warehouse_from_unlisted_role():
         },
     }
     expected = {
-        "use role useradmin",
+        "alter warehouse bar set warehouse_size = 'x-small'",
+        "create role if not exists foo",
+        "create warehouse if not exists bar with warehouse_size = 'x-small' auto_suspend = 30 initially_suspended = true",
         'grant role foo to role "SYSADMIN"',
         'revoke usage on warehouse bar from role "ROGUE_ROLE"',
+        "use role sysadmin",
+        "use role useradmin",
     }
     result = set(execution_plan(config=config, state=state))
     print(result)
@@ -1076,7 +1251,11 @@ def test_revoke_warehouse_from_unlisted_role():
 
 
 def test_revoke_warehouse_when_not_in_config():
-    config = {"grants": [{"role": "foo", "warehouses": ["bar"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "warehouses": [{"name": "bar"}],
+        "grants": [{"role": "foo", "warehouses": ["bar"]}],
+    }
     state = {
         "grants": {
             "on_warehouses": {
@@ -1087,10 +1266,14 @@ def test_revoke_warehouse_when_not_in_config():
         },
     }
     expected = {
-        "use role useradmin",
+        "alter warehouse bar set warehouse_size = 'x-small'",
+        "create role if not exists foo",
+        "create warehouse if not exists bar with warehouse_size = 'x-small' auto_suspend = 30 initially_suspended = true",
+        'grant role foo to role "SYSADMIN"',
         "grant usage on warehouse bar to role foo",
         'revoke usage on warehouse bar from role "BAZ"',
-        'grant role foo to role "SYSADMIN"',
+        "use role sysadmin",
+        "use role useradmin",
     }
     result = set(execution_plan(config=config, state=state))
     print(result)
@@ -1099,9 +1282,9 @@ def test_revoke_warehouse_when_not_in_config():
 
 def test_grant_and_revoke_warehouse_mixed():
     config = {
-        "grants": [
-            {"role": "foo", "warehouses": ["wh1", "wh2"]},
-        ]
+        "roles": [{"name": "foo"}],
+        "warehouses": [{"name": "wh1"}, {"name": "wh2"}],
+        "grants": [{"role": "foo", "warehouses": ["wh1", "wh2"]}],
     }
     state = {
         "grants": {
@@ -1115,10 +1298,16 @@ def test_grant_and_revoke_warehouse_mixed():
         },
     }
     expected = {
-        "use role useradmin",
+        "alter warehouse wh1 set warehouse_size = 'x-small'",
+        "alter warehouse wh2 set warehouse_size = 'x-small'",
+        "create role if not exists foo",
+        "create warehouse if not exists wh1 with warehouse_size = 'x-small' auto_suspend = 30 initially_suspended = true",
+        "create warehouse if not exists wh2 with warehouse_size = 'x-small' auto_suspend = 30 initially_suspended = true",
+        'grant role foo to role "SYSADMIN"',
         "grant usage on warehouse wh2 to role foo",
         'revoke usage on warehouse wh1 from role "OLD_ROLE"',
-        'grant role foo to role "SYSADMIN"',
+        "use role sysadmin",
+        "use role useradmin",
     }
     result = set(execution_plan(config=config, state=state))
     print(result)
@@ -1127,10 +1316,12 @@ def test_grant_and_revoke_warehouse_mixed():
 
 def test_warehouse_grants_aggregated_across_entries():
     config = {
+        "roles": [{"name": "foo"}, {"name": "bar"}],
+        "warehouses": [{"name": "wh1"}],
         "grants": [
             {"role": "foo", "warehouses": ["wh1"]},
             {"role": "bar", "warehouses": ["wh1"]},
-        ]
+        ],
     }
     state = {
         "grants": {
@@ -1148,7 +1339,11 @@ def test_warehouse_grants_aggregated_across_entries():
 
 
 def test_warehouse_ownership_not_revoked():
-    config = {"grants": [{"role": "foo", "warehouses": ["bar"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "warehouses": [{"name": "bar"}],
+        "grants": [{"role": "foo", "warehouses": ["bar"]}],
+    }
     state = {
         "grants": {
             "on_warehouses": {
@@ -1160,8 +1355,12 @@ def test_warehouse_ownership_not_revoked():
         },
     }
     expected = {
-        "use role useradmin",
+        "alter warehouse bar set warehouse_size = 'x-small'",
+        "create role if not exists foo",
+        "create warehouse if not exists bar with warehouse_size = 'x-small' auto_suspend = 30 initially_suspended = true",
         'grant role foo to role "SYSADMIN"',
+        "use role sysadmin",
+        "use role useradmin",
     }
     result = set(execution_plan(config=config, state=state))
     print(result)
@@ -1172,7 +1371,11 @@ def test_warehouse_ownership_not_revoked():
 
 
 def test_database_usage_skipped_when_already_exists():
-    config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+        "grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}],
+    }
     state = {
         "grants": {
             "on_databases": {
@@ -1209,7 +1412,11 @@ def test_database_usage_skipped_when_already_exists():
 
 
 def test_database_usage_granted_when_missing():
-    config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+        "grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}],
+    }
     state = {
         "grants": {
             "on_databases": {"db1": []},
@@ -1222,7 +1429,11 @@ def test_database_usage_granted_when_missing():
 
 
 def test_database_usage_revoked_from_unlisted_role():
-    config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+        "grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}],
+    }
     state = {
         "grants": {
             "on_databases": {
@@ -1242,10 +1453,12 @@ def test_database_usage_revoked_from_unlisted_role():
 
 def test_database_usage_aggregated_across_read_and_write():
     config = {
+        "roles": [{"name": "reader"}, {"name": "writer"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}, {"name": "sch2"}]}],
         "grants": [
             {"role": "reader", "read_on_schemas": ["db1.sch1"]},
             {"role": "writer", "write_on_schemas": ["db1.sch2"]},
-        ]
+        ],
     }
     state = {
         "grants": {
@@ -1268,7 +1481,11 @@ def test_database_usage_aggregated_across_read_and_write():
 
 
 def test_schema_usage_skipped_when_already_exists():
-    config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+        "grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}],
+    }
     state = {
         "grants": {
             "on_databases": {"db1": []},
@@ -1285,7 +1502,11 @@ def test_schema_usage_skipped_when_already_exists():
 
 
 def test_schema_usage_revoked_from_unlisted_role():
-    config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+        "grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}],
+    }
     state = {
         "grants": {
             "on_databases": {"db1": []},
@@ -1304,10 +1525,12 @@ def test_schema_usage_revoked_from_unlisted_role():
 
 def test_schema_usage_aggregated_across_read_and_write():
     config = {
+        "roles": [{"name": "reader"}, {"name": "writer"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
         "grants": [
             {"role": "reader", "read_on_schemas": ["db1.sch1"]},
             {"role": "writer", "write_on_schemas": ["db1.sch1"]},
-        ]
+        ],
     }
     state = {
         "grants": {
@@ -1328,9 +1551,9 @@ def test_schema_usage_aggregated_across_read_and_write():
 
 def test_schema_usage_aggregated_from_read_on_objects():
     config = {
-        "grants": [
-            {"role": "obj_reader", "read_on_objects": ["table:db1.sch1.t1"]},
-        ]
+        "roles": [{"name": "obj_reader"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+        "grants": [{"role": "obj_reader", "read_on_objects": ["table:db1.sch1.t1"]}],
     }
     state = {
         "grants": {
@@ -1352,7 +1575,11 @@ def test_schema_usage_aggregated_from_read_on_objects():
 
 
 def test_future_read_skipped_when_already_exists():
-    config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+        "grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}],
+    }
     state = {
         "grants": {
             "on_databases": {"db1": []},
@@ -1389,7 +1616,11 @@ def test_future_read_skipped_when_already_exists():
 
 
 def test_future_read_granted_when_missing():
-    config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+        "grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}],
+    }
     state = {
         "grants": {
             "on_databases": {"db1": []},
@@ -1409,7 +1640,11 @@ def test_future_read_granted_when_missing():
 
 
 def test_future_read_revoked_from_unlisted_role():
-    config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+        "grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}],
+    }
     state = {
         "grants": {
             "on_databases": {"db1": []},
@@ -1485,7 +1720,11 @@ def test_future_read_revoked_from_unlisted_role():
 
 def test_all_grants_skipped_when_future_grants_already_exist():
     """ALL grants are skipped when all future grants already exist in state."""
-    config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+        "grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}],
+    }
     state = {
         "grants": {
             "on_databases": {
@@ -1532,7 +1771,11 @@ def test_all_grants_skipped_when_future_grants_already_exist():
 
 def test_all_grants_skipped_with_underscored_grant_on():
     """Snowflake returns DYNAMIC_TABLE/SEMANTIC_VIEW with underscores — must still match."""
-    config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+        "grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}],
+    }
     state = {
         "grants": {
             "on_databases": {"db1": [{"privilege": "USAGE", "grantee_name": "FOO"}]},
@@ -1576,7 +1819,11 @@ def test_all_grants_skipped_with_underscored_grant_on():
 
 def test_all_grants_emitted_when_future_grants_missing():
     """ALL grants are emitted when future grants are being newly added."""
-    config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+        "grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}],
+    }
     state = {
         "grants": {
             "on_databases": {"db1": []},
@@ -1595,7 +1842,11 @@ def test_all_grants_emitted_when_future_grants_missing():
 
 
 def test_create_grants_skipped_when_already_exists():
-    config = {"grants": [{"role": "foo", "write_on_schemas": ["db1.sch1"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+        "grants": [{"role": "foo", "write_on_schemas": ["db1.sch1"]}],
+    }
     state = {
         "grants": {
             "on_databases": {"db1": []},
@@ -1619,7 +1870,11 @@ def test_create_grants_skipped_when_already_exists():
 
 
 def test_create_grants_granted_when_missing():
-    config = {"grants": [{"role": "foo", "write_on_schemas": ["db1.sch1"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+        "grants": [{"role": "foo", "write_on_schemas": ["db1.sch1"]}],
+    }
     state = {
         "grants": {
             "on_databases": {"db1": []},
@@ -1634,7 +1889,11 @@ def test_create_grants_granted_when_missing():
 
 
 def test_create_grants_revoked_from_unlisted_role():
-    config = {"grants": [{"role": "foo", "write_on_schemas": ["db1.sch1"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+        "grants": [{"role": "foo", "write_on_schemas": ["db1.sch1"]}],
+    }
     state = {
         "grants": {
             "on_databases": {"db1": []},
@@ -1656,7 +1915,11 @@ def test_create_grants_revoked_from_unlisted_role():
 
 def test_create_grants_partial_missing():
     """Some CREATE types exist, some don't — only grants the missing ones."""
-    config = {"grants": [{"role": "foo", "write_on_schemas": ["db1.sch1"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+        "grants": [{"role": "foo", "write_on_schemas": ["db1.sch1"]}],
+    }
     state = {
         "grants": {
             "on_databases": {"db1": []},
@@ -1677,7 +1940,11 @@ def test_create_grants_partial_missing():
 
 
 def test_object_select_skipped_when_already_exists():
-    config = {"grants": [{"role": "foo", "read_on_objects": ["table:db1.sch1.t1"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+        "grants": [{"role": "foo", "read_on_objects": ["table:db1.sch1.t1"]}],
+    }
     state = {
         "grants": {
             "on_databases": {"db1": []},
@@ -1694,7 +1961,11 @@ def test_object_select_skipped_when_already_exists():
 
 
 def test_object_select_granted_when_missing():
-    config = {"grants": [{"role": "foo", "read_on_objects": ["table:db1.sch1.t1"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+        "grants": [{"role": "foo", "read_on_objects": ["table:db1.sch1.t1"]}],
+    }
     state = {
         "grants": {
             "on_databases": {"db1": []},
@@ -1707,7 +1978,11 @@ def test_object_select_granted_when_missing():
 
 
 def test_object_select_revoked_from_unlisted_role():
-    config = {"grants": [{"role": "foo", "read_on_objects": ["table:db1.sch1.t1"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+        "grants": [{"role": "foo", "read_on_objects": ["table:db1.sch1.t1"]}],
+    }
     state = {
         "grants": {
             "on_databases": {"db1": []},
@@ -1728,10 +2003,12 @@ def test_object_select_revoked_from_unlisted_role():
 def test_object_select_not_revoked_when_covered_by_read_on_schemas():
     """A role with read_on_schemas should not have its object SELECT revoked."""
     config = {
+        "roles": [{"name": "analyst"}, {"name": "special"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
         "grants": [
             {"role": "analyst", "read_on_schemas": ["db1.sch1"]},
             {"role": "special", "read_on_objects": ["table:db1.sch1.t1"]},
-        ]
+        ],
     }
     state = {
         "grants": {
@@ -1758,10 +2035,12 @@ def test_object_select_not_revoked_when_covered_by_read_on_schemas():
 def test_object_select_revoked_when_not_covered_by_schema_or_object():
     """A role not in read_on_schemas or read_on_objects should be revoked."""
     config = {
+        "roles": [{"name": "analyst"}, {"name": "special"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
         "grants": [
             {"role": "analyst", "read_on_schemas": ["db1.sch1"]},
             {"role": "special", "read_on_objects": ["table:db1.sch1.t1"]},
-        ]
+        ],
     }
     state = {
         "grants": {
@@ -1787,6 +2066,9 @@ def test_object_select_revoked_when_not_covered_by_schema_or_object():
 def test_stateless_mode_grants_unconditionally():
     """When no state is provided, all grants are emitted unconditionally."""
     config = {
+        "roles": [{"name": "foo"}],
+        "warehouses": [{"name": "wh1"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}, {"name": "sch2"}]}],
         "grants": [
             {
                 "role": "foo",
@@ -1795,7 +2077,7 @@ def test_stateless_mode_grants_unconditionally():
                 "read_on_objects": ["table:db1.sch1.t1"],
                 "warehouses": ["wh1"],
             }
-        ]
+        ],
     }
     result = set(execution_plan(config=config))
     assert "grant usage on database db1 to role foo" in result
@@ -1915,7 +2197,11 @@ def test_role_ownership_not_transferred_when_correct():
 
 
 def test_unmanaged_privilege_revoked_on_database():
-    config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+        "grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}],
+    }
     state = {
         "grants": {
             "on_databases": {
@@ -1939,7 +2225,11 @@ def test_unmanaged_privilege_revoked_on_database():
 
 
 def test_unmanaged_privilege_revoked_on_warehouse():
-    config = {"grants": [{"role": "foo", "warehouses": ["wh1"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "warehouses": [{"name": "wh1"}],
+        "grants": [{"role": "foo", "warehouses": ["wh1"]}],
+    }
     state = {
         "grants": {
             "on_warehouses": {
@@ -1961,10 +2251,12 @@ def test_unmanaged_privilege_revoked_on_warehouse():
 
 def test_unmanaged_privilege_revoked_on_schema():
     config = {
+        "roles": [{"name": "foo"}, {"name": "bar"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
         "grants": [
             {"role": "foo", "read_on_schemas": ["db1.sch1"]},
             {"role": "bar", "write_on_schemas": ["db1.sch1"]},
-        ]
+        ],
     }
     state = {
         "grants": {
@@ -1991,7 +2283,11 @@ def test_unmanaged_privilege_revoked_on_schema():
 
 def test_unmanaged_privilege_not_revoked_without_state():
     """When no state is available, nothing should be revoked."""
-    config = {"grants": [{"role": "foo", "warehouses": ["wh1"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "warehouses": [{"name": "wh1"}],
+        "grants": [{"role": "foo", "warehouses": ["wh1"]}],
+    }
     result = set(execution_plan(config=config))
     assert not any("revoke" in s for s in result)
 
@@ -2001,7 +2297,11 @@ def test_unmanaged_privilege_not_revoked_without_state():
 
 def test_revoke_warehouse_usage_from_user_grantee():
     """User-level resource grants are unmanaged and should be revoked with proper SQL."""
-    config = {"grants": [{"role": "foo", "warehouses": ["bar"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "warehouses": [{"name": "bar"}],
+        "grants": [{"role": "foo", "warehouses": ["bar"]}],
+    }
     state = {
         "grants": {
             "on_warehouses": {
@@ -2022,7 +2322,11 @@ def test_revoke_warehouse_usage_from_user_grantee():
 
 
 def test_revoke_database_usage_from_user_grantee():
-    config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+        "grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}],
+    }
     state = {
         "grants": {
             "on_databases": {
@@ -2045,7 +2349,11 @@ def test_revoke_database_usage_from_user_grantee():
 
 
 def test_revoke_schema_usage_from_user_grantee():
-    config = {"grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+        "grants": [{"role": "foo", "read_on_schemas": ["db1.sch1"]}],
+    }
     state = {
         "grants": {
             "on_databases": {"db1": []},
@@ -2069,7 +2377,11 @@ def test_revoke_schema_usage_from_user_grantee():
 
 def test_user_grantee_not_included_in_role_diff():
     """User grantees should not interfere with role grant/revoke diffing."""
-    config = {"grants": [{"role": "foo", "warehouses": ["bar"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "warehouses": [{"name": "bar"}],
+        "grants": [{"role": "foo", "warehouses": ["bar"]}],
+    }
     state = {
         "grants": {
             "on_warehouses": {
@@ -2093,7 +2405,11 @@ def test_user_grantee_not_included_in_role_diff():
 
 def test_unmanaged_privilege_revoked_with_correct_grantee_type():
     """Unmanaged privileges should use correct grantee type from state."""
-    config = {"grants": [{"role": "foo", "warehouses": ["wh1"]}]}
+    config = {
+        "roles": [{"name": "foo"}],
+        "warehouses": [{"name": "wh1"}],
+        "grants": [{"role": "foo", "warehouses": ["wh1"]}],
+    }
     state = {
         "grants": {
             "on_warehouses": {
@@ -2116,9 +2432,9 @@ def test_unmanaged_privilege_revoked_with_correct_grantee_type():
 def test_schema_single_pass_revokes_mixed_privileges():
     """Schema diff revokes usage, create, and unmanaged privs in a single pass."""
     config = {
-        "grants": [
-            {"role": "reader", "read_on_schemas": ["db1.sch1"]},
-        ]
+        "roles": [{"name": "reader"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+        "grants": [{"role": "reader", "read_on_schemas": ["db1.sch1"]}],
     }
     state = {
         "grants": {
@@ -2173,9 +2489,9 @@ def test_schema_single_pass_revokes_mixed_privileges():
 def test_object_select_revokes_non_select_privileges():
     """Object diff revokes non-select privileges dynamically from state."""
     config = {
-        "grants": [
-            {"role": "reader", "read_on_objects": ["table:db1.sch1.tbl1"]},
-        ]
+        "roles": [{"name": "reader"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+        "grants": [{"role": "reader", "read_on_objects": ["table:db1.sch1.tbl1"]}],
     }
     state = {
         "grants": {
@@ -2218,9 +2534,9 @@ def test_object_select_revokes_non_select_privileges():
 def test_future_grants_revokes_non_select_privileges():
     """Future grants diff revokes non-select privileges dynamically from state."""
     config = {
-        "grants": [
-            {"role": "reader", "read_on_schemas": ["db1.sch1"]},
-        ]
+        "roles": [{"name": "reader"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+        "grants": [{"role": "reader", "read_on_schemas": ["db1.sch1"]}],
     }
     state = {
         "grants": {
@@ -2268,7 +2584,11 @@ def test_future_grants_revokes_non_select_privileges():
 
 def test_future_read_revoked_when_only_write_on_schemas():
     """Future read grants must be revoked when schema is only in write_on_schemas."""
-    config = {"grants": [{"role": "writer", "write_on_schemas": ["db1.sch1"]}]}
+    config = {
+        "roles": [{"name": "writer"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+        "grants": [{"role": "writer", "write_on_schemas": ["db1.sch1"]}],
+    }
     state = {
         "grants": {
             "on_databases": {"db1": []},
@@ -2338,9 +2658,9 @@ def test_future_read_revoked_when_only_write_on_schemas():
 def test_future_read_revoked_when_only_read_on_objects():
     """Future read grants must be revoked when schema is only in read_on_objects."""
     config = {
-        "grants": [
-            {"role": "obj_reader", "read_on_objects": ["table:db1.sch1.t1"]}
-        ]
+        "roles": [{"name": "obj_reader"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+        "grants": [{"role": "obj_reader", "read_on_objects": ["table:db1.sch1.t1"]}],
     }
     state = {
         "grants": {
@@ -2377,10 +2697,12 @@ def test_future_read_revoked_when_only_read_on_objects():
 def test_future_read_no_regression_with_read_and_write():
     """Schema in both read_on_schemas and write_on_schemas: future reads preserved."""
     config = {
+        "roles": [{"name": "reader"}, {"name": "writer"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
         "grants": [
             {"role": "reader", "read_on_schemas": ["db1.sch1"]},
             {"role": "writer", "write_on_schemas": ["db1.sch1"]},
-        ]
+        ],
     }
     state = {
         "grants": {
@@ -2416,14 +2738,16 @@ def test_future_read_no_regression_with_read_and_write():
     # reader's future grants should NOT be revoked
     assert not any("revoke" in s and "reader" in s.lower() for s in result)
     # writer should NOT get future read grants
-    assert not any(
-        "grant select on future" in s and "writer" in s for s in result
-    )
+    assert not any("grant select on future" in s and "writer" in s for s in result)
 
 
 def test_future_read_writer_role_revoked_on_write_only_schema():
     """Writer role's stale future read grants revoked on write-only schema."""
-    config = {"grants": [{"role": "writer", "write_on_schemas": ["db1.sch1"]}]}
+    config = {
+        "roles": [{"name": "writer"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+        "grants": [{"role": "writer", "write_on_schemas": ["db1.sch1"]}],
+    }
     state = {
         "grants": {
             "on_databases": {"db1": []},
@@ -2449,9 +2773,9 @@ def test_future_read_writer_role_revoked_on_write_only_schema():
 def test_future_grants_does_not_revoke_ownership():
     """Future grants diff must never revoke OWNERSHIP."""
     config = {
-        "grants": [
-            {"role": "reader", "read_on_schemas": ["db1.sch1"]},
-        ]
+        "roles": [{"name": "reader"}],
+        "databases": [{"name": "db1", "schemas": [{"name": "sch1"}]}],
+        "grants": [{"role": "reader", "read_on_schemas": ["db1.sch1"]}],
     }
     state = {
         "grants": {


### PR DESCRIPTION
## What

Managed objects (for state fetching and grant diffing) are now derived from spec declaration sections (`databases:`, `warehouses:`, `roles:`) instead of scanning the `grants` section.

## Why

Previously, objects declared in the spec but not referenced in grants were invisible to state management. A warehouse in `warehouses:` but not in any grant would never have stale grants revoked. A role in `roles:` with no grant entry would keep stale role assignments.

## Changes

**`state.py`** — State-fetching functions derive managed objects from spec:
- `_get_warehouse_grants` → uses `warehouses:` section
- `_get_database_grants` → uses `databases:` section
- `_get_schema_grants` / `_get_future_schema_grants` → uses `databases[].schemas`
- `_get_object_grants` stays grant-based (objects are referenced, not declared)

**`plan.py`** — Grant diffing covers all managed objects:
- `_validate_grant_references()` + `UnmanagedReferenceError` — errors when grants reference undeclared objects
- Synthetic grant entries for managed roles without grants → sysadmin auto-granted
- Diff loops iterate over `managed_*` sets, not just grant-referenced objects
- Managed objects with no grants → stale grants revoked

**Tests** — 67 tests updated with spec sections, 6 new tests added